### PR TITLE
Fix invalid manifest resources_generated keys

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,5 @@
     }
   },
   "tools_generated": true,
-  "prompts_generated": false,
-  "resources_generated": false
+  "prompts_generated": false
 }


### PR DESCRIPTION
The MCPB specification only supports tools_generated and prompts_generated fields. The resources_generated field is not a valid manifest key.