### PR TITLE
Debug Claude installation errors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
     "mcp_config": {
       "command": "uv",
       "args": [
+        "--quiet",
         "--directory",
         "${__dirname}",
         "run",

--- a/server.py
+++ b/server.py
@@ -39,11 +39,7 @@ from server.text_processing.sentence_splitter import initialize_sentence_splitte
 
 logger = logging.getLogger(__name__)
 # Explicitly configure logging to use stderr to avoid breaking MCP JSON-RPC protocol on stdout
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    stream=sys.stderr
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s", stream=sys.stderr)
 logger.debug("Starting server.py initialization")
 
 mcp = FastMCP("Writing Tools MCP Server")

--- a/server.py
+++ b/server.py
@@ -18,6 +18,7 @@
 
 import logging
 import statistics
+import sys
 
 import numpy as np
 import torch
@@ -37,7 +38,12 @@ from server.text_processing import initialize_preprocessor
 from server.text_processing.sentence_splitter import initialize_sentence_splitter
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+# Explicitly configure logging to use stderr to avoid breaking MCP JSON-RPC protocol on stdout
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    stream=sys.stderr
+)
 logger.debug("Starting server.py initialization")
 
 mcp = FastMCP("Writing Tools MCP Server")

--- a/server/models/spacy_manager.py
+++ b/server/models/spacy_manager.py
@@ -1,6 +1,8 @@
 """spaCy model management."""
 
 import logging
+import sys
+from contextlib import redirect_stdout
 from pathlib import Path
 
 import spacy
@@ -34,5 +36,7 @@ class SpacyManager:
             logger.info("Downloading spaCy English model, this may take a while...")
             from spacy.cli import download
 
-            download(self.model_name)
+            # Redirect stdout to stderr to avoid breaking MCP JSON-RPC protocol
+            with redirect_stdout(sys.stderr):
+                download(self.model_name)
             return spacy.load(self.model_name)


### PR DESCRIPTION
This commit addresses JSON parse errors that occurred during MCPB installation by ensuring all non-JSON output is redirected to stderr:

1. Added --quiet flag to uv command in manifest.json to suppress package installation progress output
2. Redirected spaCy model download output to stderr using redirect_stdout
3. Explicitly configured logging to use stderr instead of defaulting to stdout

These changes ensure only valid JSON-RPC messages are sent to stdout, preventing "Unexpected token" errors in Claude Desktop.

Fixes installation errors where uv and spacy.cli.download were outputting progress messages to stdout, breaking the MCP protocol.