### PR TITLE
Declare the en_core_web_sm spaCy model as a pinned dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Install dependencies
         run: uv pip install -e ".[dev]"
 
-      - name: Install spaCy English model
-        run: uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
-
       - name: Run linter
         run: uv run ruff check .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "torch>=2.0.0",
     "pyyaml>=6.0",
     "numpy>=1.24.0",
+    # Direct URL ref; would need to become an optional extra if ever published to PyPI.
+    "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl",
 ]
 
 [project.optional-dependencies]
@@ -47,6 +49,9 @@ ignore = ["E501", "C901"]
 
 [tool.ruff.format]
 quote-style = "double"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["server"]

--- a/run_server.py
+++ b/run_server.py
@@ -12,7 +12,8 @@
 #   "transformers>=4.35.0",
 #   "torch>=2.0.0",
 #   "pyyaml>=6.0",
-#   "numpy>=1.24.0"
+#   "numpy>=1.24.0",
+#   "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
 # ]
 # ///
 """Standalone launcher for the Writing Tools MCP server.

--- a/uv.lock
+++ b/uv.lock
@@ -557,6 +557,14 @@ wheels = [
 ]
 
 [[package]]
+name = "en-core-web-sm"
+version = "3.8.0"
+source = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" }
+wheels = [
+    { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl", hash = "sha256:1932429db727d4bff3deed6b34cfc05df17794f4a52eeb26cf8928f7c1a0fb85" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2950,6 +2958,7 @@ name = "writing-tools-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "en-core-web-sm" },
     { name = "fastmcp" },
     { name = "markdown-it-py" },
     { name = "numpy" },
@@ -2971,6 +2980,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "fastmcp", specifier = ">=2.14.0,<3.0.0" },
     { name = "markdown-it-py" },
     { name = "numpy", specifier = ">=1.24.0" },


### PR DESCRIPTION
Closes #12

## What changed

`en_core_web_sm` is required by nearly every tool (all spaCy-backed analyzers go through `get_analyzers()` → `spacy_manager.get_model()`), but it wasn't declared anywhere. Installs resolved cleanly and then shelled out a network download on the **first tool call** — which fails in offline, sandboxed, or read-only environments, with no signal at dependency-resolution time that anything was missing.

- **`pyproject.toml`** — declares `en_core_web_sm` as a pinned direct-reference dependency on the 3.8.0 wheel (the same version CI was installing by URL).
- **`pyproject.toml`** — adds `[tool.hatch.metadata] allow-direct-references = true`. This is required: hatchling hard-fails the wheel build with `Dependency #11 of field 'project.dependencies' cannot be a direct reference` without it. Worth knowing that a resolver dry-run does *not* surface this, since it never builds the wheel.
- **`run_server.py`** — the same declaration in the PEP-723 block. This is a second copy of the dependency list, and it's the path `uv run run_server.py` and the Claude Desktop bundle use; leaving it out would mean those launches still downloaded at runtime.
- **`.github/workflows/test.yml`** — drops the now-redundant explicit wheel install step, so the test job installs the model *via the declaration* and thereby regression-tests it.
- **`uv.lock`** — regenerated to match.

The direct-URL form is chosen over a PyPI-safe extra because this package is distributed via git/`uvx`/source, where pip and uv both support it. A one-line comment notes the constraint for anyone who later considers publishing to PyPI.

`SpacyManager._load_model`'s runtime download fallback is untouched and still functions as a safety net.

## Verification

Everything below was run locally.

**The acceptance criterion — clean install, no runtime download.** Installed into a fresh Python 3.12 venv with `uv pip install .`, then exercised the actual code under test with the download path sabotaged, so any fallback to it would raise rather than silently pass:

```python
import spacy.cli
def boom(*a, **k):
    raise AssertionError('FAIL: runtime download fallback was invoked')
spacy.cli.download = boom

from server.models.spacy_manager import SpacyManager
nlp = SpacyManager().get_model()
```

Result: `OK: model loaded with no download`, `pipeline: core_web_sm 3.8.0`, and POS tagging returned real output (`[('The','DET'), ('report','NOUN'), ('was','AUX'), ('written','VERB')]`). Run from outside the worktree so it imported the installed package, not the source tree.

**The full CI gate**, reproduced locally after `uv pip install -e ".[dev]"` (with no separate model install, matching the updated workflow):

- `uv run ruff check .` → All checks passed!
- `uv run ruff format --check .` → 38 files already formatted
- `uv run pytest tests/ -q` → **144 passed**. `tests/conftest.py` loads a real spaCy model as a session fixture, so a green suite here is itself evidence the model resolved from the declaration.
- The workflow's entry-point step → `Entry point server.app:main resolves`
- `uv pip list` confirms `en-core-web-sm 3.8.0` present with `spacy 3.8.5` — within the model's `>=3.8.0,<3.9.0` requirement.

**Packaging.** `uv build` produces both wheel and sdist; wheel `METADATA` carries `Requires-Dist: en-core-web-sm @ https://github.com/.../en_core_web_sm-3.8.0-py3-none-any.whl`.
