### PR TITLE
Make MCPB version extraction portable

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -51,7 +51,7 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
           else
-            VERSION=$(grep -Po '(?<=version = ")[^"]*' pyproject.toml)
+            VERSION=$(uv run --no-project python scripts/get_version.py)
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "ruff",
     "pytest",
     "pre-commit",
+    "tomli; python_version < '3.11'",
 ]
 
 [project.urls]

--- a/scripts/build_mcpb.sh
+++ b/scripts/build_mcpb.sh
@@ -9,7 +9,7 @@ echo "Building Writing Tools MCP Bundle..."
 # Configuration
 BUILD_DIR="build/mcpb"
 BUNDLE_NAME="writing-tools-mcp.mcpb"
-VERSION=$(grep -Po '(?<=version = ")[^"]*' pyproject.toml)
+VERSION=$(uv run --no-project python scripts/get_version.py)
 
 # Clean previous build
 echo "Cleaning previous build..."

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Print ``project.version`` from pyproject.toml without relying on GNU grep."""
+
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # Python 3.10
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError:
+        tomllib = None  # type: ignore[assignment]
+
+
+def read_version(pyproject: Path) -> str:
+    if tomllib is not None:
+        with pyproject.open("rb") as fh:
+            return tomllib.load(fh)["project"]["version"]
+
+    # Fallback for Python 3.10 without the ``tomli`` backport installed.
+    in_project = False
+    for line in pyproject.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_project = stripped == "[project]"
+            continue
+        if in_project:
+            key, sep, value = stripped.partition("=")
+            if sep and key.strip() == "version":
+                return value.strip().strip("'\"")
+    raise SystemExit("Could not find project.version in pyproject.toml")
+
+
+def main() -> None:
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    print(read_version(pyproject))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_version_extraction.py
+++ b/tests/test_version_extraction.py
@@ -1,0 +1,46 @@
+"""Regression check for the portable version extraction used by the bundle build.
+
+Exercises ``scripts/get_version.py`` without relying on GNU grep and asserts it
+returns ``project.version`` from pyproject.toml.
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+SCRIPT = ROOT / "scripts" / "get_version.py"
+
+
+def _expected_version() -> str:
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)["project"]["version"]
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("get_version", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_read_version_matches_pyproject():
+    module = _load_script()
+    assert module.read_version(PYPROJECT) == _expected_version()
+
+
+def test_script_cli_matches_pyproject():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == _expected_version()

--- a/uv.lock
+++ b/uv.lock
@@ -2976,6 +2976,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -2992,6 +2993,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "spacy" },
     { name = "textstat" },
+    { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'" },
     { name = "torch", specifier = ">=2.0.0" },
     { name = "transformers", specifier = ">=4.35.0" },
 ]


### PR DESCRIPTION
Closes #21

## Summary
`scripts/build_mcpb.sh` extracted the project version with `grep -Po` and a Perl lookbehind. macOS ships BSD grep, which has no `-P`, so `make` bundle builds aborted under `set -e` before producing an artifact. The same GNU-only expression was duplicated in `.github/workflows/build-mcpb.yml` for non-tag builds.

## Changes
- Add `scripts/get_version.py`: reads `project.version` from `pyproject.toml` via `tomllib` (Python 3.11+), falling back to `tomli` (3.10) and then to a small stdlib-only parser, so it needs no GNU grep and no third-party package to run.
- `scripts/build_mcpb.sh` and the workflow's non-tag branch now both derive the version from this single script (`uv run --no-project python scripts/get_version.py`), using the project's existing `uv` toolchain.
- Tag builds are unchanged — release metadata still comes from the tag (`${GITHUB_REF#refs/tags/v}`).
- Add `tomli; python_version < '3.11'` to the `dev` extra so the 3.10 fallback path is real and the test can parse the TOML independently.
- Add `tests/test_version_extraction.py`: asserts the extracted version (via the function and via the script's CLI) equals `project.version` from `pyproject.toml`, without invoking grep.

## Verification
Ran locally with the repo's `uv` toolchain:
- `python3 scripts/get_version.py` and `uv run --no-project python scripts/get_version.py` → both print `0.1.0`.
- Forced the no-`tomllib` fallback parser → prints `0.1.0`.
- `uv run ruff check .` and `uv run ruff format --check .` → all checks pass.
- `uv run pytest tests/` → 159 passed.
- `bash scripts/build_mcpb.sh` → succeeds, reports `Version: 0.1.0`; the resulting `writing-tools-mcp.mcpb` contains `manifest.json`, `run_server.py`, and the `server/` package.
- `grep -rn 'grep -P' scripts/ .github/` → no matches remain.
