### PR TITLE
Keep standalone launcher dependencies in sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "packaging",
     "ruff",
     "pytest",
     "pre-commit",
+    "tomli; python_version < '3.11'",
 ]
 
 [project.urls]

--- a/run_server.py
+++ b/run_server.py
@@ -2,7 +2,6 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#   "pip",
 #   "fastmcp>=2.14.0,<3.0.0",
 #   "pyspellchecker",
 #   "textstat",

--- a/tests/test_launcher_dependencies.py
+++ b/tests/test_launcher_dependencies.py
@@ -1,0 +1,56 @@
+"""Keep the standalone launcher's runtime dependencies aligned with the project."""
+
+import re
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).parent.parent
+
+
+def _load_toml(path):
+    with path.open("rb") as file:
+        return tomllib.load(file)
+
+
+def _load_script_metadata(path):
+    content = path.read_text(encoding="utf-8")
+    match = re.search(r"(?ms)^# /// script\s*$\n(?P<metadata>(?:^#.*$\n)+)^# ///\s*$", content)
+    assert match, f"PEP 723 script metadata not found in {path}"
+
+    metadata = re.sub(r"(?m)^# ?", "", match.group("metadata"))
+    return tomllib.loads(metadata)
+
+
+def _normalize(requirement_string):
+    requirement = Requirement(requirement_string)
+    return (
+        canonicalize_name(requirement.name),
+        tuple(sorted(canonicalize_name(extra) for extra in requirement.extras)),
+        str(requirement.specifier),
+        requirement.url,
+        str(requirement.marker) if requirement.marker else None,
+    )
+
+
+def test_standalone_launcher_dependencies_match_project_dependencies():
+    project_dependencies = _load_toml(ROOT / "pyproject.toml")["project"]["dependencies"]
+    launcher_dependencies = _load_script_metadata(ROOT / "run_server.py")["dependencies"]
+
+    project = {_normalize(requirement): requirement for requirement in project_dependencies}
+    launcher = {_normalize(requirement): requirement for requirement in launcher_dependencies}
+    missing = sorted(project[key] for key in project.keys() - launcher.keys())
+    extra = sorted(launcher[key] for key in launcher.keys() - project.keys())
+
+    assert not missing and not extra, (
+        "Standalone launcher dependencies differ from project.dependencies.\n"
+        f"Missing from run_server.py: {missing}\n"
+        f"Extra in run_server.py: {extra}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2973,9 +2973,11 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "packaging" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -2984,6 +2986,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.14.0,<3.0.0" },
     { name = "markdown-it-py" },
     { name = "numpy", specifier = ">=1.24.0" },
+    { name = "packaging", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pyspellchecker" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -2992,6 +2995,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "spacy" },
     { name = "textstat" },
+    { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'" },
     { name = "torch", specifier = ">=2.0.0" },
     { name = "transformers", specifier = ">=4.35.0" },
 ]


### PR DESCRIPTION
Closes #20

## Summary

- parse the real `project.dependencies` and PEP 723 launcher metadata in a focused test
- normalize requirement names, extras, specifiers, URLs, and markers before comparing dependency sets
- report launcher dependencies that are missing or extra, and remove the unexplained launcher-only `pip` declaration
- declare the lightweight TOML and requirement parsers as dev dependencies for Python 3.10–3.12

## Verification

- `uv pip install -e ".[dev]"` — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed (41 files already formatted)
- `uv run pytest tests/ -v` — passed (158 tests)
- `uv run python -c "from server.app import main; assert callable(main)"` — passed
- `uv run run_server.py` — resolved the PEP 723 environment and reached FastMCP stdio server startup
- Mutation check: adding a launcher-only dependency failed with `Extra in run_server.py`; removing a project dependency failed with the corresponding launcher extra, then both mutations were restored
