### PR TITLE
Confine baseline file access to approved directories

### DIFF
--- a/server/stylometry/baselines.py
+++ b/server/stylometry/baselines.py
@@ -7,10 +7,59 @@ baseline statistics for comparing stylometric features against human writing.
 
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+BASELINES_DIR = Path(__file__).parent.parent / "data" / "baselines"
+CUSTOM_BASELINES_SUBDIR = "custom_baselines"
+
+_SAFE_BASELINE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _validate_baseline_name(baseline_name: str) -> str:
+    """
+    Validate that a baseline name is a plain identifier, not a path.
+
+    Args:
+        baseline_name: Name of the baseline
+
+    Returns:
+        The validated baseline name
+
+    Raises:
+        ValueError: If the name is empty, contains path separators, parent
+            references, or any other character outside the allowed set
+    """
+    if not isinstance(baseline_name, str) or not _SAFE_BASELINE_NAME.match(baseline_name) or ".." in baseline_name:
+        raise ValueError(
+            f"Invalid baseline name {baseline_name!r}: baseline names must contain only letters, digits, "
+            "'.', '_' or '-', and may not contain path separators or parent directory references"
+        )
+    return baseline_name
+
+
+def _resolve_baseline_file(directory: Path, baseline_name: str) -> Optional[Path]:
+    """
+    Resolve ``<directory>/<baseline_name>.json`` and confirm it stays inside ``directory``.
+
+    Args:
+        directory: Approved baseline directory
+        baseline_name: Already-validated baseline name
+
+    Returns:
+        The resolved path, or None if it would escape the approved directory
+    """
+    approved_dir = directory.resolve()
+    candidate = (approved_dir / f"{baseline_name}.json").resolve()
+
+    if not candidate.is_relative_to(approved_dir) or candidate == approved_dir:
+        logger.error(f"Rejected baseline path outside approved directory: {candidate}")
+        return None
+
+    return candidate
 
 
 class BaselineManager:
@@ -44,8 +93,10 @@ class BaselineManager:
             Dictionary containing baseline statistics
 
         Raises:
-            ValueError: If baseline is not found
+            ValueError: If the name is not a valid baseline identifier, or the baseline is not found
         """
+        _validate_baseline_name(baseline_name)
+
         if baseline_name in self.baselines:
             return self.baselines[baseline_name]
 
@@ -73,20 +124,16 @@ class BaselineManager:
 
         Returns:
             Path to the baseline file or None if not found
+
+        Raises:
+            ValueError: If the name is not a valid baseline identifier
         """
-        # Check in data/baselines directory
-        data_dir = Path(__file__).parent.parent / "data" / "baselines"
-        baseline_file = data_dir / f"{baseline_name}.json"
+        _validate_baseline_name(baseline_name)
 
-        if baseline_file.exists():
-            return baseline_file
-
-        # Check in custom baselines directory
-        custom_dir = data_dir / "custom_baselines"
-        custom_file = custom_dir / f"{baseline_name}.json"
-
-        if custom_file.exists():
-            return custom_file
+        for directory in (BASELINES_DIR, BASELINES_DIR / CUSTOM_BASELINES_SUBDIR):
+            baseline_file = _resolve_baseline_file(directory, baseline_name)
+            if baseline_file is not None and baseline_file.is_file():
+                return baseline_file
 
         return None
 
@@ -149,18 +196,19 @@ class BaselineManager:
 
         Returns:
             True if saved successfully, False otherwise
+
+        Raises:
+            ValueError: If the name is not a valid baseline identifier
         """
+        _validate_baseline_name(baseline_name)
+
+        data_dir = BASELINES_DIR / CUSTOM_BASELINES_SUBDIR if custom else BASELINES_DIR
+
         try:
-            if custom:
-                # Save to custom baselines directory
-                data_dir = Path(__file__).parent.parent / "data" / "baselines" / "custom_baselines"
-                data_dir.mkdir(parents=True, exist_ok=True)
-                baseline_path = data_dir / f"{baseline_name}.json"
-            else:
-                # Save to main baselines directory
-                data_dir = Path(__file__).parent.parent / "data" / "baselines"
-                data_dir.mkdir(parents=True, exist_ok=True)
-                baseline_path = data_dir / f"{baseline_name}.json"
+            data_dir.mkdir(parents=True, exist_ok=True)
+            baseline_path = _resolve_baseline_file(data_dir, baseline_name)
+            if baseline_path is None:
+                raise ValueError(f"Refusing to write baseline outside of {data_dir}")
 
             with open(baseline_path, "w", encoding="utf-8") as f:
                 json.dump(baseline_data, f, indent=2, ensure_ascii=False)
@@ -191,7 +239,7 @@ class BaselineManager:
                 available[name] = "Custom baseline"
 
         # Check for file-based baselines
-        data_dir = Path(__file__).parent.parent / "data" / "baselines"
+        data_dir = BASELINES_DIR
         if data_dir.exists():
             for baseline_file in data_dir.glob("*.json"):
                 name = baseline_file.stem
@@ -199,7 +247,7 @@ class BaselineManager:
                     available[name] = "File-based baseline"
 
         # Check custom baselines directory
-        custom_dir = data_dir / "custom_baselines"
+        custom_dir = data_dir / CUSTOM_BASELINES_SUBDIR
         if custom_dir.exists():
             for baseline_file in custom_dir.glob("*.json"):
                 name = baseline_file.stem

--- a/tests/test_stylometry.py
+++ b/tests/test_stylometry.py
@@ -5,6 +5,8 @@ This module tests the StylemetricAnalyzer, BaselineManager, statistical function
 and the integrated stylometric_analysis tool.
 """
 
+import json
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,6 +20,7 @@ from server.stylometry import (
     flag_outliers,
     generate_flags,
 )
+from server.stylometry import baselines as baselines_module
 
 # Test data
 SAMPLE_HUMAN_TEXT = """
@@ -242,6 +245,136 @@ class TestBaselineManager:
 
         assert "brown_corpus" in baselines
         assert isinstance(baselines["brown_corpus"], str)
+
+
+class TestBaselineNameSafety:
+    """Test that baseline names are treated as identifiers rather than paths."""
+
+    @pytest.fixture
+    def baselines_dir(self, tmp_path, monkeypatch):
+        """Point BaselineManager at a temporary baseline directory tree."""
+        data_dir = tmp_path / "data" / "baselines"
+        (data_dir / "custom_baselines").mkdir(parents=True)
+        monkeypatch.setattr(baselines_module, "BASELINES_DIR", data_dir)
+        return data_dir
+
+    @pytest.fixture
+    def external_file(self, tmp_path):
+        """A readable JSON file outside every approved baseline directory."""
+        external = tmp_path / "outside" / "secret.json"
+        external.parent.mkdir(parents=True)
+        external.write_text(json.dumps({"statistics": {"secret": True}}), encoding="utf-8")
+        return external
+
+    def test_builtin_baseline_unchanged(self):
+        """The in-memory brown_corpus baseline still loads."""
+        manager = BaselineManager()
+        assert manager.load_baseline("brown_corpus")["corpus_info"]["name"] == "Brown Corpus"
+
+    def test_file_backed_builtin_baseline_loads(self, baselines_dir):
+        """A JSON file in the built-in baseline directory loads by name."""
+        (baselines_dir / "news_corpus.json").write_text(json.dumps(SAMPLE_BASELINE), encoding="utf-8")
+
+        manager = BaselineManager()
+        assert manager.load_baseline("news_corpus") == SAMPLE_BASELINE
+
+    def test_custom_baseline_loads(self, baselines_dir):
+        """A JSON file in the custom baseline directory loads by name."""
+        custom_path = baselines_dir / "custom_baselines" / "my_corpus-v1.0.json"
+        custom_path.write_text(json.dumps(SAMPLE_BASELINE), encoding="utf-8")
+
+        manager = BaselineManager()
+        assert manager.load_baseline("my_corpus-v1.0") == SAMPLE_BASELINE
+
+    @pytest.mark.parametrize(
+        "baseline_name",
+        [
+            "/etc/passwd",
+            "/tmp/external",
+            "../secret",
+            "..",
+            "custom_baselines/../../secret",
+            "custom_baselines/my_corpus",
+            "sub\\corpus",
+            "",
+            ".hidden",
+            "corpus\x00",
+        ],
+    )
+    def test_load_baseline_rejects_unsafe_names(self, baselines_dir, baseline_name):
+        """Absolute paths, traversal, and separators are rejected with a clear error."""
+        manager = BaselineManager()
+
+        with pytest.raises(ValueError, match="Invalid baseline name"):
+            manager.load_baseline(baseline_name)
+
+        with pytest.raises(ValueError, match="Invalid baseline name"):
+            manager._get_baseline_path(baseline_name)
+
+    def test_external_file_cannot_be_loaded(self, baselines_dir, external_file):
+        """A crafted name cannot read a JSON file outside the approved directories."""
+        manager = BaselineManager()
+        absolute_name = str(external_file)[: -len(".json")]
+        relative_name = os.path.relpath(external_file, baselines_dir)[: -len(".json")]
+
+        for crafted in (absolute_name, relative_name):
+            with pytest.raises(ValueError, match="Invalid baseline name"):
+                manager.load_baseline(crafted)
+            assert crafted not in manager.baselines
+
+    def test_symlink_out_of_baseline_dir_is_rejected(self, baselines_dir, external_file):
+        """A symlinked baseline resolving outside the approved directory is not loaded."""
+        (baselines_dir / "linked.json").symlink_to(external_file)
+
+        manager = BaselineManager()
+        with pytest.raises(ValueError, match="not found"):
+            manager.load_baseline("linked")
+
+    def test_missing_valid_name_still_reports_not_found(self, baselines_dir):
+        """A well-formed but unknown baseline keeps the original not-found error."""
+        manager = BaselineManager()
+
+        with pytest.raises(ValueError, match="not found"):
+            manager.load_baseline("no_such_baseline")
+
+    def test_get_baseline_info_returns_none_for_unsafe_name(self, baselines_dir, external_file):
+        """get_baseline_info swallows the validation error rather than raising."""
+        manager = BaselineManager()
+        assert manager.get_baseline_info(str(external_file)[: -len(".json")]) is None
+
+    def test_save_baseline_rejects_unsafe_names(self, baselines_dir, external_file):
+        """A crafted name cannot overwrite a file outside the approved directories."""
+        manager = BaselineManager()
+        original = external_file.read_text(encoding="utf-8")
+
+        for crafted in (
+            str(external_file)[: -len(".json")],
+            os.path.relpath(external_file, baselines_dir / "custom_baselines")[: -len(".json")],
+            "../escaped",
+        ):
+            with pytest.raises(ValueError, match="Invalid baseline name"):
+                manager.save_baseline(crafted, SAMPLE_BASELINE)
+
+        assert external_file.read_text(encoding="utf-8") == original
+        assert not (baselines_dir.parent.parent / "escaped.json").exists()
+
+    def test_save_baseline_writes_inside_custom_dir(self, baselines_dir):
+        """Valid names still round-trip through the custom baseline directory."""
+        manager = BaselineManager()
+
+        assert manager.save_baseline("my_corpus-v1.0", SAMPLE_BASELINE) is True
+        assert (baselines_dir / "custom_baselines" / "my_corpus-v1.0.json").is_file()
+        assert BaselineManager().load_baseline("my_corpus-v1.0") == SAMPLE_BASELINE
+
+    def test_stylometric_analysis_reports_unsafe_baseline(self, baselines_dir, external_file):
+        """The MCP-facing analyzer returns a structured error for a crafted baseline."""
+        analyzer = AIDetectionAnalyzer(MagicMock(), MagicMock(), {})
+
+        result = analyzer.stylometric_analysis("Some text to analyze.", baseline=str(external_file)[: -len(".json")])
+
+        assert "Invalid baseline name" in result["error"]
+        assert result["features"] == {}
+        assert result["flags"]["high_ai_probability"] is False
 
 
 class TestStatisticalFunctions:


### PR DESCRIPTION
Closes #19

## What changed

`stylometric_analysis` passes a caller-controlled `baseline` string straight to `BaselineManager`, which joined it into a filesystem path. An absolute value replaced the intended base directory, so any readable JSON file whose path could be written with an implicit `.json` suffix was loadable over MCP.

Baseline names are now identifiers, not paths (`server/stylometry/baselines.py`):

- `_validate_baseline_name` accepts only `[A-Za-z0-9][A-Za-z0-9._-]*` and additionally rejects any `..` substring, so absolute paths, parent traversal, POSIX/Windows separators, empty names, and dotfiles raise a clear `ValueError`.
- `_resolve_baseline_file` resolves `<dir>/<name>.json` and verifies with `is_relative_to` that the result stays inside the approved directory — this is a second, independent barrier that also rejects a symlink inside a baseline directory pointing outside it.
- `load_baseline`, `_get_baseline_path` and `save_baseline` all go through both. `save_baseline` cannot write outside its selected directory even though baseline mutation is not exposed over MCP today.
- The two baseline directories are now the module constants `BASELINES_DIR` / `CUSTOM_BASELINES_SUBDIR` instead of four repeated `Path(__file__).parent.parent / ...` expressions; the paths themselves are unchanged.

Behavior for callers is otherwise unchanged: `brown_corpus` and valid file-backed/custom names load exactly as before, an unknown-but-valid name still raises the original `Baseline '<name>' not found`, and `AIDetectionAnalyzer.stylometric_analysis` already catches `ValueError` so a rejected name comes back as the normal structured `error` result rather than a protocol error.

## Verification

Ran the full CI gate locally with `uv` (`uv pip install -e ".[dev]"`):

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — `42 files already formatted`
- `uv run pytest tests/` — **179 passed** (20 of them new in `TestBaselineNameSafety`)

New tests cover valid built-in, file-backed and custom names; parametrized rejection of absolute paths, `..`, `/` and `\` separators, empty and dotfile names; that a temp JSON file outside the baseline tree cannot be read via an absolute or relative crafted name; that the same crafted names cannot overwrite it through `save_baseline` (file content asserted unchanged); the symlink escape; and that the analyzer surfaces `Invalid baseline name` as a structured error.

Both halves of the fix were mutation-tested to confirm the tests are not vacuous:

- Neutering the name validation → 13 of the 20 fail.
- Neutering the resolved-path containment check (validation intact) → the symlink-escape test fails.

Restored after each; `git diff` confirms only the intended changes remain.