### PR TITLE
Wire perplexity configuration into GPT-2 initialization

### DIFF
--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -12,10 +12,10 @@ __all__ = [
 def initialize_models(config):
     """Initialize model managers with configuration (lazy loading)."""
     spacy_config = config.get("spacy", {})
-    gpt2_config = config.get("gpt2", {})
+    perplexity_config = config.get("perplexity", {})
 
     spacy_manager = SpacyManager(model_name=spacy_config.get("model_name", "en_core_web_sm"))
-    gpt2_manager = GPT2Manager(gpt2_config)
+    gpt2_manager = GPT2Manager(perplexity_config)
 
     # Return managers instead of loaded models for lazy loading
     return {"spacy": spacy_manager, "gpt2": gpt2_manager}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,10 @@
 """Test module for model management."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
-from server.models import GPT2Manager, SpacyManager
+from server.analyzers import AIDetectionAnalyzer
+from server.config import load_config
+from server.models import GPT2Manager, SpacyManager, initialize_models
 
 
 class TestSpacyManager:
@@ -74,3 +76,64 @@ class TestGPT2Manager:
         assert model == mock_model_instance
         assert tokenizer == mock_tokenizer_instance
         assert returned_config == config
+
+
+DISTINCTIVE_PERPLEXITY_CONFIG = {
+    "model_name": "distilgpt2",
+    "max_length": 128,
+    "overlap": 7,
+    "thresholds": {"ppl_max": 12.5, "burstiness_min": 4.0},
+    "device": "cpu",
+    "language": "en",
+}
+
+
+class TestInitializeModels:
+    """Test that initialize_models wires configuration through to the managers."""
+
+    def test_gpt2_manager_receives_perplexity_section(self):
+        """The GPT-2 manager is configured from the documented 'perplexity' section."""
+        config = {"perplexity": DISTINCTIVE_PERPLEXITY_CONFIG, "stylometry": {}, "logging": {}}
+
+        gpt2_manager = initialize_models(config)["gpt2"]
+
+        assert gpt2_manager.config == DISTINCTIVE_PERPLEXITY_CONFIG
+        assert gpt2_manager.config["model_name"] == "distilgpt2"
+        assert gpt2_manager.config["max_length"] == 128
+        assert gpt2_manager.config["overlap"] == 7
+        assert gpt2_manager.config["thresholds"] == {"ppl_max": 12.5, "burstiness_min": 4.0}
+
+    def test_loaded_config_supplies_keys_the_analysis_path_indexes(self):
+        """Defaults loaded from disk reach the manager with every key perplexity analysis indexes."""
+        gpt2_manager = initialize_models(load_config())["gpt2"]
+
+        for key in ("model_name", "max_length", "overlap", "thresholds"):
+            assert key in gpt2_manager.config
+        for threshold in ("ppl_max", "burstiness_min"):
+            assert threshold in gpt2_manager.config["thresholds"]
+
+    @patch("server.analyzers.ai_detection.split_into_sentences")
+    def test_perplexity_analysis_uses_the_wired_configuration(self, mock_split):
+        """A full perplexity analysis succeeds and reports the configured model and thresholds."""
+        mock_split.return_value = ["A configured sentence.", "Another configured sentence."]
+
+        config = {"perplexity": DISTINCTIVE_PERPLEXITY_CONFIG, "stylometry": {}, "logging": {}}
+        gpt2_manager = initialize_models(config)["gpt2"]
+
+        # Populate the lazy cache directly so no real GPT-2 weights are fetched.
+        gpt2_manager._model = Mock()
+        gpt2_manager._tokenizer = Mock()
+        gpt2_manager._tokenizer.encode.return_value = [1, 2, 3]
+
+        analyzer = AIDetectionAnalyzer(Mock(), gpt2_manager, config)
+        with patch.object(AIDetectionAnalyzer, "_calculate_perplexity", side_effect=[8.0, 9.0]):
+            result = analyzer.perplexity_analysis("A configured sentence. Another configured sentence.")
+
+        assert "error" not in result
+        assert result["config"] == {
+            "model": "distilgpt2",
+            "thresholds": {"ppl_max": 12.5, "burstiness_min": 4.0},
+        }
+        assert result["doc_ppl"] == 8.5
+        # doc_ppl 8.5 < ppl_max 12.5 and burstiness 0.71 < burstiness_min 4.0
+        assert result["flags"]["high_ai_probability"] is True


### PR DESCRIPTION
Closes #25

## What changed

`initialize_models()` read `config.get("gpt2", {})`, but the GPT-2 settings are defined under `perplexity` in both `server/config/defaults.py` and `.mcp-config.yaml`. There is no `gpt2` section anywhere, so `GPT2Manager` was always constructed with `{}`:

- `AIDetectionAnalyzer.perplexity_analysis` indexes `config["max_length"]`, `config["overlap"]`, `config["thresholds"]` and `config["model_name"]`, so every configured perplexity analysis raised `KeyError: 'max_length'` and returned `{"error": "Analysis failed: 'max_length'", ...}` instead of a result.
- User overrides under the documented `perplexity` key were silently ignored.

The fix is one line: read `config.get("perplexity", {})`. The public configuration key is unchanged; the `spacy` lookup is left alone (that section is also absent, but `SpacyManager` has a working default — out of scope here).

Existing analyzer tests inject a separately constructed mock manager, so none of them touched this wiring. Three tests now cover it in `tests/test_models.py::TestInitializeModels`:

- `test_gpt2_manager_receives_perplexity_section` — passes a distinctive `perplexity` config through `initialize_models` and asserts the manager's exact `model_name`, `max_length`, `overlap` and thresholds.
- `test_loaded_config_supplies_keys_the_analysis_path_indexes` — runs the real `load_config()` and asserts every key the analysis path indexes is present on the manager.
- `test_perplexity_analysis_uses_the_wired_configuration` — drives a full `perplexity_analysis` against a manager built by `initialize_models` (lazy model cache populated with mocks so no GPT-2 weights are fetched), asserting no `error` key and that the returned `config` reports the configured model and thresholds.

## Verification

Environment: `uv venv .venv --seed`, `uv pip install -e ".[dev]"`.

- Reproduced on the base branch: `initialize_models(load_config())["gpt2"].config` returned `{}`. After the fix it returns `{'model_name': 'gpt2', 'max_length': 512, 'overlap': 50, 'thresholds': {'ppl_max': 25.0, 'burstiness_min': 2.5}, 'device': 'cpu', 'language': 'en'}`.
- **Mutation test — the new tests are not vacuous.** Reverting only the one-line fix back to `config.get("gpt2", {})` fails all three new tests and nothing else: `3 failed, 6 passed` in `tests/test_models.py`. The third failure is exactly the reported bug — `assert 'error' not in {'error': "Analysis failed: 'max_length'", ...}`. Restored, then re-ran the full gate.
- Full CI gate, all green: `uv run ruff check .` (All checks passed), `uv run ruff format --check .` (43 files already formatted), `uv run pytest tests/` — **183 passed** (180 before this PR).
