### PR TITLE
Stop NaN perplexities from failing the whole analysis

### DIFF
--- a/server/analyzers/ai_detection.py
+++ b/server/analyzers/ai_detection.py
@@ -93,10 +93,10 @@ class AIDetectionAnalyzer:
                         sentence_ppl = float("inf")
 
                     sentence_results.append(
-                        {"text": sentence, "ppl": round(sentence_ppl, 2) if not np.isinf(sentence_ppl) else None}
+                        {"text": sentence, "ppl": round(sentence_ppl, 2) if np.isfinite(sentence_ppl) else None}
                     )
 
-                    if not np.isinf(sentence_ppl):
+                    if np.isfinite(sentence_ppl):
                         sentence_perplexities.append(sentence_ppl)
 
             # Calculate document-level perplexity
@@ -112,7 +112,7 @@ class AIDetectionAnalyzer:
             flags = {"high_ai_probability": False, "reasons": []}
             thresholds = config["thresholds"]
 
-            if not np.isinf(doc_ppl) and doc_ppl < thresholds["ppl_max"]:
+            if np.isfinite(doc_ppl) and doc_ppl < thresholds["ppl_max"]:
                 if doc_burstiness < thresholds["burstiness_min"]:
                     flags["high_ai_probability"] = True
                     flags["reasons"].append(
@@ -128,7 +128,7 @@ class AIDetectionAnalyzer:
                 )
 
             return {
-                "doc_ppl": round(doc_ppl, 2) if not np.isinf(doc_ppl) else None,
+                "doc_ppl": round(doc_ppl, 2) if np.isfinite(doc_ppl) else None,
                 "doc_burstiness": round(doc_burstiness, 2),
                 "sentences": sentence_results,
                 "config": {"model": config["model_name"], "thresholds": thresholds},
@@ -295,6 +295,13 @@ class AIDetectionAnalyzer:
             # Calculate perplexity from loss
             perplexity = torch.exp(torch.tensor(loss)).item()
 
+            # A single-token input gives the model nothing to predict, so the loss
+            # comes back NaN and so does exp(loss). NaN is not a usable perplexity
+            # and it poisons every downstream aggregation, so report it the same
+            # way as a failed calculation.
+            if not np.isfinite(perplexity):
+                return float("inf")
+
             return perplexity
 
         except Exception as e:
@@ -306,8 +313,10 @@ class AIDetectionAnalyzer:
         if len(sentence_perplexities) < 2:
             return 0.0
 
-        # Filter out infinite values
-        valid_perplexities = [p for p in sentence_perplexities if not np.isinf(p)]
+        # Filter out non-finite values. `statistics.stdev` raises
+        # "cannot convert NaN to integer ratio" on a NaN, which previously failed
+        # the whole analysis, so this must reject NaN as well as infinity.
+        valid_perplexities = [p for p in sentence_perplexities if np.isfinite(p)]
 
         if len(valid_perplexities) < 2:
             return 0.0

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
+import torch
 
 from server.analyzers import AIDetectionAnalyzer
 
@@ -119,3 +120,76 @@ class TestPerplexityAnalysis:
         mock_tokenizer.side_effect = Exception("Model error")
         perplexity = analyzer._calculate_perplexity("test text", mock_model, mock_tokenizer)
         assert np.isinf(perplexity)
+
+
+class TestPerplexityNaNHandling:
+    """NaN perplexities must never reach the aggregations.
+
+    A sentence that tokenizes to a single token gives GPT-2 nothing to predict, so
+    the model returns a NaN loss and `exp(loss)` is NaN. NaN passes an `isinf`
+    check, so it used to flow into the document average (making it NaN) and into
+    `statistics.stdev`, which raises "cannot convert NaN to integer ratio" and
+    failed the entire analysis.
+    """
+
+    @pytest.fixture
+    def analyzer(self):
+        mock_config = {"gpt2": {"model_name": "gpt2", "cache_dir": "models/gpt2", "tokenizer": "gpt2"}}
+        return AIDetectionAnalyzer(Mock(), Mock(), mock_config)
+
+    def test_burstiness_filters_nan(self, analyzer):
+        """stdev must not see a NaN, and the result stays finite."""
+        with_nan = [10.0, float("nan"), 15.0, 12.0, float("nan"), 18.0]
+        burstiness = analyzer._calculate_burstiness(with_nan)
+        assert np.isfinite(burstiness)
+        assert burstiness > 0
+
+    def test_burstiness_filters_nan_and_inf_together(self, analyzer):
+        mixed = [10.0, float("nan"), float("inf"), 15.0, float("-inf"), 12.0]
+        assert np.isfinite(analyzer._calculate_burstiness(mixed))
+
+    def test_burstiness_all_nan_returns_zero(self, analyzer):
+        assert analyzer._calculate_burstiness([float("nan"), float("nan")]) == 0.0
+
+    def test_calculate_perplexity_converts_nan_to_inf(self, analyzer):
+        """A NaN loss from the model is reported as a failed calculation."""
+        mock_model = Mock()
+        mock_tokenizer = Mock()
+
+        mock_inputs = Mock()
+        mock_inputs.input_ids = torch.tensor([[42]])  # single token
+        mock_tokenizer.return_value = mock_inputs
+
+        mock_outputs = Mock()
+        mock_outputs.loss = torch.tensor(float("nan"))
+        mock_model.return_value = mock_outputs
+
+        perplexity = analyzer._calculate_perplexity("Hi", mock_model, mock_tokenizer)
+        assert np.isinf(perplexity), "NaN loss must be reported as inf, never as NaN"
+
+    def test_analysis_survives_a_nan_sentence(self, analyzer):
+        """End to end: one NaN sentence must not fail the whole analysis."""
+        mock_model, mock_tokenizer = Mock(), Mock()
+        config = {
+            "model_name": "gpt2",
+            "max_length": 512,
+            "overlap": 50,
+            "thresholds": {"ppl_max": 50, "burstiness_min": 1.0},
+        }
+        analyzer.gpt2_manager.get_model_and_tokenizer.return_value = (mock_model, mock_tokenizer, config)
+
+        sentences = ["A real sentence here.", "Hi", "Another real sentence here."]
+        values = iter([20.0, float("nan"), 40.0])
+
+        with (
+            patch("server.analyzers.ai_detection.split_into_sentences", return_value=sentences),
+            patch.object(analyzer, "_chunk_text", side_effect=lambda s, *a, **k: [s]),
+            patch.object(analyzer, "_calculate_perplexity", side_effect=lambda *a, **k: next(values)),
+        ):
+            result = analyzer.perplexity_analysis("irrelevant, sentences are patched")
+
+        assert result.get("error") is None, f"analysis failed: {result.get('error')}"
+        assert result["doc_ppl"] == 30.0, "the NaN sentence must be excluded from the average"
+        assert np.isfinite(result["doc_burstiness"])
+        # the NaN sentence is still reported, with a null score
+        assert [s["ppl"] for s in result["sentences"]] == [20.0, None, 40.0]


### PR DESCRIPTION
## Problem

`perplexity_analysis` returned `{"error": "Analysis failed: cannot convert NaN
to integer ratio", "doc_ppl": None}` on real documents. Reproduced on a ~800
word blog post; 1 of its 43 sentences triggered it.

A sentence that tokenizes to a single token gives GPT-2 nothing to predict, so
`outputs.loss` is NaN and `torch.exp(NaN)` is NaN. That value is returned
through the success path, because the only guard is the `except` block.

Every downstream check tested `np.isinf`, which NaN passes:

- the NaN was appended to `sentence_perplexities`
- `doc_ppl` averaged it, so the document score became NaN
- `_calculate_burstiness` filtered only infinities, so `statistics.stdev` saw
  the NaN and raised `ValueError: cannot convert NaN to integer ratio`, which
  the outer handler turned into a failed analysis
- `round(nan, 2)` also leaked a NaN into the per-sentence output
- the threshold comparisons silently evaluated False against NaN, so flags
  degraded without saying so

## Fix

Treat NaN as a failed calculation at the source, and use `np.isfinite` rather
than `not np.isinf` at every aggregation point:

- `_calculate_perplexity` returns `inf` when the computed perplexity is not
  finite, matching how it already reports errors
- `_calculate_burstiness` filters with `np.isfinite`
- the sentence accumulator, the per-sentence `ppl` field, the `doc_ppl` output
  and the threshold check all use `np.isfinite`

An unscorable sentence is now excluded from the aggregates and reported as
`"ppl": null`, instead of failing the request.

## Verification

- `uv run pytest` — 189 passed.
- `uv run ruff check .` — all checks passed.
- New `TestPerplexityNaNHandling`: burstiness with NaN, with NaN and inf mixed,
  all-NaN, a NaN loss from the model, and an end-to-end analysis where a NaN
  sentence is excluded from the average (asserts `doc_ppl == 30.0` from
  `[20.0, nan, 40.0]`) and reported as null.
- Mutation check, each applied alone:
  - reverting the burstiness filter to `not np.isinf` fails 3 tests with the
    original `ValueError: cannot convert NaN to integer ratio`
  - removing the NaN guard in `_calculate_perplexity` fails
    `test_calculate_perplexity_converts_nan_to_inf`
  Both restored; the suite is green.
- Against the document that first failed: `error: None`, `doc_ppl: 169.38`,
  `burstiness: 201.74`, 43 sentences with the 1 unscorable one reported as null.

## Not done

The single-token case is inherent to causal LM scoring, so this reports it as
unscorable rather than trying to score it. Scoring such sentences would need a
different approach (for example prepending a BOS token) and a decision about
whether that number is comparable to the others.