### PR TITLE
Stop scoring undefined sentence-length variance as a uniform-sentence AI indicator

### DIFF
--- a/server/stylometry/analyzer.py
+++ b/server/stylometry/analyzer.py
@@ -8,7 +8,7 @@ AI-generated content.
 
 import statistics
 from collections import Counter
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class StylemetricAnalyzer:
@@ -164,7 +164,7 @@ class StylemetricAnalyzer:
         """Return empty/default feature values for empty text."""
         return {
             "avg_sentence_len": 0.0,
-            "sentence_len_std": 0.0,
+            "sentence_len_std": None,
             "sentence_positions": [],
             "ttr": 0.0,
             "hapax_legomena_rate": 0.0,
@@ -188,17 +188,17 @@ class StylemetricAnalyzer:
 
         return statistics.mean(lengths) if lengths else 0.0
 
-    def _sentence_length_std(self, sentences) -> float:
-        """Calculate standard deviation of sentence lengths."""
+    def _sentence_length_std(self, sentences) -> Optional[float]:
+        """Calculate standard deviation of sentence lengths, or None if undefined."""
         if len(sentences) < 2:
-            return 0.0
+            return None
 
         lengths = []
         for sent in sentences:
             word_count = sum(1 for token in sent if not token.is_punct and not token.is_space)
             lengths.append(word_count)
 
-        return statistics.stdev(lengths) if len(lengths) > 1 else 0.0
+        return statistics.stdev(lengths) if len(lengths) > 1 else None
 
     def _sentence_positions(self, sentences) -> List[Dict[str, Any]]:
         """Extract detailed information about each sentence."""

--- a/server/stylometry/statistical.py
+++ b/server/stylometry/statistical.py
@@ -38,6 +38,11 @@ def calculate_z_scores(features: Dict[str, Any], baseline: Dict[str, Any]) -> Di
             feature_value = features[feature]
             baseline_stats = baseline[feature]
 
+            # A feature that could not be measured has no z-score at all; scoring
+            # it as if it were 0.0 would misreport an absent value as an outlier.
+            if feature_value is None:
+                continue
+
             if isinstance(baseline_stats, dict) and "mean" in baseline_stats and "std" in baseline_stats:
                 mean = baseline_stats["mean"]
                 std = baseline_stats["std"]

--- a/tests/test_stylometry.py
+++ b/tests/test_stylometry.py
@@ -446,6 +446,76 @@ class TestStatisticalFunctions:
         assert result[1]["z_score"] == 1.0  # (20-15)/5
 
 
+class TestUndefinedSentenceLengthStd:
+    """Sentence-length dispersion must be absent, not zero, when it cannot be measured."""
+
+    SINGLE_SENTENCE_TEXT = "The committee approved the revised budget yesterday after a long and contentious debate."
+
+    UNIFORM_SENTENCES_TEXT = (
+        "The committee approved the revised budget yesterday. "
+        "The council rejected the amended proposal quickly. "
+        "The board reviewed the updated schedule carefully."
+    )
+
+    @pytest.fixture
+    def analyzer(self):
+        """Create a mock analyzer for testing."""
+        return StylemetricAnalyzer(MagicMock())
+
+    @staticmethod
+    def _mock_sentences(word_counts):
+        """Build mock spaCy sentences with the given non-punctuation token counts."""
+        sentences = []
+        for word_count in word_counts:
+            sent = MagicMock()
+            tokens = [MagicMock() for _ in range(word_count)]
+            for token in tokens:
+                token.is_punct = False
+                token.is_space = False
+            sent.__iter__ = lambda self, tokens=tokens: iter(tokens)
+            sentences.append(sent)
+        return sentences
+
+    @pytest.mark.parametrize("word_counts", [[], [12]])
+    def test_std_is_none_when_undefined(self, analyzer, word_counts):
+        """Fewer than two sentences means no dispersion measurement exists."""
+        assert analyzer._sentence_length_std(self._mock_sentences(word_counts)) is None
+
+    def test_std_is_sample_stdev_for_two_or_more_sentences(self, analyzer):
+        """Two or more sentences still yield the sample standard deviation."""
+        result = analyzer._sentence_length_std(self._mock_sentences([5, 15]))
+        assert abs(result - 7.07) < 0.01
+
+    def test_z_scores_omit_unmeasurable_feature(self):
+        """A None feature value is skipped; numeric values are scored as before."""
+        features = {"sentence_len_std": None, "avg_sentence_len": 20.0}
+
+        z_scores = calculate_z_scores(features, SAMPLE_BASELINE["statistics"])
+
+        assert "sentence_len_std" not in z_scores
+        assert abs(z_scores["avg_sentence_len"] - 1.0) < 0.01
+
+    def test_single_sentence_is_not_flagged_as_uniform(self, ai_detection_analyzer):
+        """A one-sentence document must not be charged a uniform-sentence indicator."""
+        result = ai_detection_analyzer.stylometric_analysis(self.SINGLE_SENTENCE_TEXT)
+
+        assert "error" not in result
+        assert result["features"]["sentence_len_std"] is None
+        assert "sentence_len_std" not in result["z_scores"]
+        assert "sentence_len_std" not in result["flags"]["warnings"]
+        assert "sentence_len_std" not in result["flags"]["errors"]
+        assert "uniform_sentences" not in result["flags"]["ai_indicators"]
+
+    def test_uniform_multi_sentence_text_still_flags_uniform_sentences(self, ai_detection_analyzer):
+        """A genuinely uniform multi-sentence document keeps the indicator."""
+        result = ai_detection_analyzer.stylometric_analysis(self.UNIFORM_SENTENCES_TEXT)
+
+        assert result["features"]["sentence_len_std"] == 0.0
+        assert result["z_scores"]["sentence_len_std"] < -2.0
+        assert "sentence_len_std" in result["flags"]["warnings"]
+        assert "uniform_sentences" in result["flags"]["ai_indicators"]
+
+
 class TestIntegration:
     """Integration tests for the complete stylometric analysis."""
 


### PR DESCRIPTION
Closes #34

## What changed

A single-sentence document has no sentence-length standard deviation, but `StylemetricAnalyzer._sentence_length_std` returned `0.0` for it. Against the shipped Brown baseline (`sentence_len_std` mean 7.1, std 2.4) that sentinel scores `z = -2.96`, which clears `warning_z` 2.0 — so every one-sentence input was charged a spurious `uniform_sentences` AI indicator (+0.2 confidence) and a `sentence_len_std` outlier warning purely because the statistic could not be measured.

- `server/stylometry/analyzer.py` — `_sentence_length_std` returns `None` (typed `Optional[float]`) for fewer than two sentences; two or more still return the sample stdev, unchanged. `_empty_features` reports `sentence_len_std: None` for consistency.
- `server/stylometry/statistical.py` — `calculate_z_scores` skips a feature whose value is `None` instead of computing a z-score from it. `generate_flags` already gates on `"sentence_len_std" in z_scores`, so the indicator and the warning simply do not fire. Features with numeric values are scored exactly as before.
- `tests/test_stylometry.py` — new `TestUndefinedSentenceLengthStd` class covering both directions.

Measured end to end with real spaCy and the shipped baseline, `'The committee approved the revised budget yesterday after a long and contentious debate.'`:

| | before | after |
|---|---|---|
| `features.sentence_len_std` | `0.0` | `null` |
| `z_scores.sentence_len_std` | `-2.96` | absent |
| `flags.warnings` | includes `sentence_len_std` | omits it |
| `flags.ai_indicators` | `uniform_sentences`, `pos_anomalies` | `pos_anomalies` |
| `flags.confidence_score` | 0.6 | 0.4 |

`sentence_len_std` is now nullable in the `features` map of a `stylometric_analysis` result. The rounding loop passes non-float values through unchanged, so `None` flows into the response with no further work.

## Verification

Full CI gate, on a clean tree:

```
uv run ruff check .          -> All checks passed!
uv run ruff format --check . -> 44 files already formatted
uv run pytest tests/         -> 195 passed
```

### Mutation testing

Three mutations, each confirmed landed by grepping the mutated line before running:

1. **Revert `_sentence_length_std`'s `None` to `0.0`** (the fix's first half) — 3 failed: `test_std_is_none_when_undefined[word_counts0]`, `[word_counts1]`, and `test_single_sentence_is_not_flagged_as_uniform` (`assert 0.0 is None`). This is the acceptance-criterion mutation.
2. **Delete the `feature_value is None` guard in `calculate_z_scores`** (the fix's second half) — 2 failed: `test_z_scores_omit_unmeasurable_feature` and `test_single_sentence_is_not_flagged_as_uniform`, the latter because `(None - mean)` raises and the analyzer's broad `except` turns it into `{"error": "Analysis failed: unsupported operand type(s) for -: 'NoneType' and 'float'", ...}`. So the two halves are separately guarded, not redundant.
3. **Disable the `uniform_sentences` branch in `generate_flags`** — the "delete the indicator instead of fixing it" mutation — 3 failed, including the new `test_uniform_multi_sentence_text_still_flags_uniform_sentences`, which drives three genuinely uniform 7-word sentences through the real analyzer and asserts `sentence_len_std == 0.0`, `z < -2.0`, the warning, and the indicator. That test is what keeps this fix from being a quiet removal of the feature.

After restoring, `git status --porcelain` was empty and the full suite was green again.