### PR TITLE
Stop reporting undefined burstiness as 0.0 and flagging single-sentence text as AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ Below is a detailed reference for each tool provided by the server.
     *   `text` (`str`): The text to analyze.
     *   `language` (`str`, optional, default=`"en"`): Language code (only "en" supported currently).
 *   **Returns**: `dict` - Analysis results including:
-    *   `doc_ppl` (`float`): Document-level perplexity score
-    *   `doc_burstiness` (`float`): Burstiness score (standard deviation of sentence perplexities)
+    *   `doc_ppl` (`float | null`): Document-level perplexity score; `null` when no sentence could be scored
+    *   `doc_burstiness` (`float | null`): Burstiness score (standard deviation of sentence perplexities); `null` when fewer than two sentences were scored, since the standard deviation is undefined there
     *   `sentences` (`list`): Sentence-level perplexity scores
     *   `config` (`dict`): Model configuration and thresholds
     *   `flags` (`dict`): AI detection flags with confidence and explanations

--- a/server/analyzers/ai_detection.py
+++ b/server/analyzers/ai_detection.py
@@ -112,24 +112,37 @@ class AIDetectionAnalyzer:
             flags = {"high_ai_probability": False, "reasons": []}
             thresholds = config["thresholds"]
 
-            if np.isfinite(doc_ppl) and doc_ppl < thresholds["ppl_max"]:
-                if doc_burstiness < thresholds["burstiness_min"]:
-                    flags["high_ai_probability"] = True
-                    flags["reasons"].append(
-                        f"Low perplexity ({doc_ppl:.2f} < {thresholds['ppl_max']}) and low burstiness ({doc_burstiness:.2f} < {thresholds['burstiness_min']})"
-                    )
-                else:
-                    flags["reasons"].append(
-                        f"Low perplexity ({doc_ppl:.2f} < {thresholds['ppl_max']}) but acceptable burstiness ({doc_burstiness:.2f})"
-                    )
-            elif doc_burstiness < thresholds["burstiness_min"]:
+            # An unmeasurable burstiness is not a low one, so it can never contribute
+            # to the AI flag. A measured burstiness implies two or more finite
+            # sentence perplexities, and therefore a finite doc_ppl.
+            burstiness_measured = doc_burstiness is not None
+            low_burstiness = burstiness_measured and doc_burstiness < thresholds["burstiness_min"]
+            low_ppl = np.isfinite(doc_ppl) and doc_ppl < thresholds["ppl_max"]
+
+            if low_ppl and low_burstiness:
+                flags["high_ai_probability"] = True
+                flags["reasons"].append(
+                    f"Low perplexity ({doc_ppl:.2f} < {thresholds['ppl_max']}) and low burstiness ({doc_burstiness:.2f} < {thresholds['burstiness_min']})"
+                )
+            elif low_ppl and burstiness_measured:
+                flags["reasons"].append(
+                    f"Low perplexity ({doc_ppl:.2f} < {thresholds['ppl_max']}) but acceptable burstiness ({doc_burstiness:.2f})"
+                )
+            elif low_ppl:
+                flags["reasons"].append(
+                    f"Low perplexity ({doc_ppl:.2f} < {thresholds['ppl_max']}); "
+                    "burstiness requires at least two scored sentences"
+                )
+            elif low_burstiness:
                 flags["reasons"].append(
                     f"Low burstiness ({doc_burstiness:.2f} < {thresholds['burstiness_min']}) but acceptable perplexity"
                 )
+            elif not burstiness_measured:
+                flags["reasons"].append("Burstiness requires at least two scored sentences")
 
             return {
                 "doc_ppl": round(doc_ppl, 2) if np.isfinite(doc_ppl) else None,
-                "doc_burstiness": round(doc_burstiness, 2),
+                "doc_burstiness": round(doc_burstiness, 2) if burstiness_measured else None,
                 "sentences": sentence_results,
                 "config": {"model": config["model_name"], "thresholds": thresholds},
                 "flags": flags,
@@ -309,9 +322,14 @@ class AIDetectionAnalyzer:
             return float("inf")
 
     def _calculate_burstiness(self, sentence_perplexities):
-        """Calculate burstiness as the standard deviation of sentence perplexities."""
+        """Calculate burstiness as the standard deviation of sentence perplexities.
+
+        Returns None when fewer than two sentences were scored: a sample standard
+        deviation is undefined there, and reporting 0.0 would be indistinguishable
+        from a real reading of "perfectly uniform".
+        """
         if len(sentence_perplexities) < 2:
-            return 0.0
+            return None
 
         # Filter out non-finite values. `statistics.stdev` raises
         # "cannot convert NaN to integer ratio" on a NaN, which previously failed
@@ -319,6 +337,6 @@ class AIDetectionAnalyzer:
         valid_perplexities = [p for p in sentence_perplexities if np.isfinite(p)]
 
         if len(valid_perplexities) < 2:
-            return 0.0
+            return None
 
         return statistics.stdev(valid_perplexities)

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -77,9 +77,10 @@ class TestPerplexityAnalysis:
         assert burstiness > 0
         assert isinstance(burstiness, float)
 
-        # Test with insufficient data
-        assert analyzer._calculate_burstiness([10.0]) == 0.0
-        assert analyzer._calculate_burstiness([]) == 0.0
+        # Test with insufficient data — a standard deviation is undefined, not zero
+        assert analyzer._calculate_burstiness([10.0]) is None
+        assert analyzer._calculate_burstiness([]) is None
+        assert analyzer._calculate_burstiness([10.0, float("inf")]) is None
 
         # Test with infinities
         perplexities_with_inf = [10.0, float("inf"), 15.0, float("inf"), 12.0]
@@ -148,8 +149,8 @@ class TestPerplexityNaNHandling:
         mixed = [10.0, float("nan"), float("inf"), 15.0, float("-inf"), 12.0]
         assert np.isfinite(analyzer._calculate_burstiness(mixed))
 
-    def test_burstiness_all_nan_returns_zero(self, analyzer):
-        assert analyzer._calculate_burstiness([float("nan"), float("nan")]) == 0.0
+    def test_burstiness_all_nan_is_undefined(self, analyzer):
+        assert analyzer._calculate_burstiness([float("nan"), float("nan")]) is None
 
     def test_calculate_perplexity_converts_nan_to_inf(self, analyzer):
         """A NaN loss from the model is reported as a failed calculation."""
@@ -193,3 +194,67 @@ class TestPerplexityNaNHandling:
         assert np.isfinite(result["doc_burstiness"])
         # the NaN sentence is still reported, with a null score
         assert [s["ppl"] for s in result["sentences"]] == [20.0, None, 40.0]
+
+
+class TestUndefinedBurstiness:
+    """Burstiness that was never measured must not be reported as 0.0.
+
+    Burstiness is the sample standard deviation of the sentence perplexities, so it
+    is undefined for fewer than two scored sentences. Reporting the sentinel 0.0
+    made every such document trip the low-burstiness branch, and any single-sentence
+    input scoring under `ppl_max` was confidently flagged as AI-generated.
+    """
+
+    @pytest.fixture
+    def analyzer(self):
+        mock_config = {"gpt2": {"model_name": "gpt2", "cache_dir": "models/gpt2", "tokenizer": "gpt2"}}
+        return AIDetectionAnalyzer(Mock(), Mock(), mock_config)
+
+    def _run(self, analyzer, sentences, perplexities):
+        """Drive perplexity_analysis over fixed per-sentence perplexities."""
+        config = {
+            "model_name": "gpt2",
+            "max_length": 512,
+            "overlap": 50,
+            "thresholds": {"ppl_max": 50, "burstiness_min": 1.0},
+        }
+        analyzer.gpt2_manager.get_model_and_tokenizer.return_value = (Mock(), Mock(), config)
+        values = iter(perplexities)
+
+        with (
+            patch("server.analyzers.ai_detection.split_into_sentences", return_value=sentences),
+            patch.object(analyzer, "_chunk_text", side_effect=lambda s, *a, **k: [s]),
+            patch.object(analyzer, "_calculate_perplexity", side_effect=lambda *a, **k: next(values)),
+        ):
+            return analyzer.perplexity_analysis("irrelevant, sentences are patched")
+
+    def test_single_sentence_is_not_flagged_as_ai(self, analyzer):
+        """A lone sentence under ppl_max has no burstiness evidence against it."""
+        result = self._run(analyzer, ["One lonely sentence."], [10.0])
+
+        assert result.get("error") is None, f"analysis failed: {result.get('error')}"
+        assert result["doc_ppl"] == 10.0
+        assert result["doc_burstiness"] is None, "one sentence gives no standard deviation"
+        assert result["flags"]["high_ai_probability"] is False
+        assert not any("low burstiness" in reason.lower() for reason in result["flags"]["reasons"])
+        assert any("at least two scored sentences" in reason for reason in result["flags"]["reasons"])
+
+    def test_all_sentences_unscored_claims_nothing(self, analyzer):
+        """Nothing was measured, so neither metric may be described as acceptable."""
+        result = self._run(analyzer, ["First one.", "Second one."], [float("inf"), float("inf")])
+
+        assert result.get("error") is None, f"analysis failed: {result.get('error')}"
+        assert result["doc_ppl"] is None
+        assert result["doc_burstiness"] is None
+        assert result["flags"]["high_ai_probability"] is False
+        assert not any("acceptable perplexity" in reason for reason in result["flags"]["reasons"])
+        assert not any("low burstiness" in reason.lower() for reason in result["flags"]["reasons"])
+
+    def test_two_scored_sentences_still_flag_on_thresholds(self, analyzer):
+        """The measurable case is unchanged: low perplexity plus low burstiness flags."""
+        result = self._run(analyzer, ["First one.", "Second one."], [10.0, 10.5])
+
+        assert result["doc_ppl"] == 10.25
+        assert result["doc_burstiness"] == pytest.approx(0.35, abs=0.01)
+        assert result["flags"]["high_ai_probability"] is True
+        assert "low burstiness" in result["flags"]["reasons"][0]


### PR DESCRIPTION
Closes #33

## Problem

`AIDetectionAnalyzer._calculate_burstiness` returned the literal `0.0` when fewer than two finite sentence perplexities were available. Burstiness is the sample standard deviation of the sentence perplexities, so it is *undefined* there — but the flag block downstream could not tell that sentinel apart from a real reading of "perfectly uniform", and the default `burstiness_min` is `2.5`, so the sentinel always tripped the low-burstiness branch.

Two wrong answers followed. Any single-sentence input whose perplexity fell under `ppl_max` was confidently reported as AI-generated on the strength of a statistic that was never computed, and a document where every sentence failed to score reported "acceptable perplexity" for a perplexity that was missing entirely.

## Change

Confined to `server/analyzers/ai_detection.py`:

- `_calculate_burstiness` returns `None` for fewer than two finite perplexities (the stdev is returned unchanged otherwise).
- `perplexity_analysis` reports `doc_burstiness: null` in that case instead of `0.0`.
- The threshold comparisons run only on a measured value, so an unmeasurable burstiness can never set `high_ai_probability`; an explanatory reason ("burstiness requires at least two scored sentences") is emitted instead.
- The "but acceptable perplexity" reason is now reachable only when burstiness was measured, which implies two or more finite sentence perplexities and therefore a finite `doc_ppl` — so it can no longer be emitted for an unmeasured perplexity.

`doc_burstiness` is now nullable; the README's tool description says so, alongside `doc_ppl`, which was already nullable in practice and is now documented as such.

## Verification

Behaviour at the shipped defaults (`ppl_max` 25.0, `burstiness_min` 2.5), driven through the real `perplexity_analysis` with GPT-2 mocked per the existing `tests/test_perplexity.py` pattern:

| sentence perplexities | `doc_ppl` | `doc_burstiness` | flags |
|---|---|---|---|
| `[10.0]` | 10.0 | `None` | `high_ai_probability: False` — "Low perplexity (10.00 < 25.0); burstiness requires at least two scored sentences" |
| `[inf, inf]` | `None` | `None` | `high_ai_probability: False` — "Burstiness requires at least two scored sentences" |
| `[10.0, 10.5]` | 10.25 | 0.35 | `high_ai_probability: True` — unchanged |
| `[10.0, 40.0]` | 25.0 | 21.21 | no reasons — unchanged |

Commands run (Python 3.12, `uv pip install -e ".[dev]"`):

- `ruff check .` → All checks passed
- `ruff format --check .` → 44 files already formatted
- `pytest tests/` → **192 passed**, including the pre-existing `test_analysis_survives_a_nan_sentence`

**Mutation test.** With `_calculate_burstiness`'s two `return None` statements reverted to `return 0.0` (mutation confirmed by grepping the file) and everything else left in place, 4 tests fail:

```
FAILED tests/test_perplexity.py::TestPerplexityAnalysis::test_burstiness_calculation
FAILED tests/test_perplexity.py::TestPerplexityNaNHandling::test_burstiness_all_nan_is_undefined
FAILED tests/test_perplexity.py::TestUndefinedBurstiness::test_single_sentence_is_not_flagged_as_ai
FAILED tests/test_perplexity.py::TestUndefinedBurstiness::test_all_sentences_unscored_claims_nothing
```

The two `TestUndefinedBurstiness` cases are the end-to-end ones. Probing the mutated code directly reproduced the original report exactly:

```
['One lonely sentence.'] -> doc_ppl 10.0  doc_burstiness 0.0
  {'high_ai_probability': True, 'reasons': ['Low perplexity (10.00 < 50) and low burstiness (0.00 < 1.0)']}
['A.', 'B.'] (both failed) -> doc_ppl None  doc_burstiness 0.0
  {'high_ai_probability': False, 'reasons': ['Low burstiness (0.00 < 1.0) but acceptable perplexity']}
```

The mutation was then reverted and the full suite re-run green, so the baseline is confirmed clean.

`test_two_scored_sentences_still_flag_on_thresholds` is the counterpart guard: it fails if the fix were taken too far and a *measured* low burstiness stopped setting the flag.