### PR TITLE
Validate user configuration before analysis

### DIFF
--- a/server/config/loader.py
+++ b/server/config/loader.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 import yaml
 
 from server.config.defaults import DEFAULT_CONFIG
+from server.config.schema import CONFIG_SCHEMA, INTEGER, NUMBER, STRING, STRING_LIST
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +30,70 @@ def load_config(config_path: str = ".mcp-config.yaml") -> Dict[str, Any]:
             with open(config_file) as f:
                 user_config = yaml.safe_load(f)
                 if user_config:
-                    config = _merge_config(config, user_config)
+                    config = _merge_config(config, _validate_config(user_config, config_path))
         except Exception as e:
             logger.warning(f"Error loading config file: {e}. Using defaults.")
 
     return config
+
+
+def _validate_config(user_config: Any, config_path: str) -> Dict[str, Any]:
+    """Drop unsupported keys and wrongly typed values from a user configuration."""
+    if not isinstance(user_config, dict):
+        logger.warning(f"{config_path} must contain a mapping, got {_type_name(user_config)}. Using defaults.")
+        return {}
+
+    return _validate_section(user_config, CONFIG_SCHEMA, "", config_path)
+
+
+def _validate_section(user: Dict[str, Any], schema: Dict[str, Any], path: str, config_path: str) -> Dict[str, Any]:
+    """Validate one mapping level against its schema, warning about every rejected entry."""
+    validated: Dict[str, Any] = {}
+
+    for key, value in user.items():
+        full_path = f"{path}.{key}" if path else str(key)
+
+        if key not in schema:
+            logger.warning(f"Unknown configuration key '{full_path}' in {config_path}. Ignoring it.")
+            continue
+
+        expected = schema[key]
+        if isinstance(expected, dict):
+            if not isinstance(value, dict):
+                logger.warning(
+                    f"Configuration key '{full_path}' must be a mapping, got {_type_name(value)}. Using defaults."
+                )
+                continue
+            validated[key] = _validate_section(value, expected, full_path, config_path)
+        elif _matches_kind(value, expected):
+            validated[key] = value
+        else:
+            logger.warning(
+                f"Configuration key '{full_path}' must be {expected}, got {_type_name(value)}. Using the default."
+            )
+
+    return validated
+
+
+def _matches_kind(value: Any, kind: str) -> bool:
+    """Check a scalar (or list) value against a schema leaf."""
+    # bool is a subclass of int, but a YAML boolean is never a valid number here.
+    if isinstance(value, bool):
+        return False
+    if kind == STRING:
+        return isinstance(value, str)
+    if kind == INTEGER:
+        return isinstance(value, int)
+    if kind == NUMBER:
+        return isinstance(value, (int, float))
+    if kind == STRING_LIST:
+        return isinstance(value, list) and all(isinstance(item, str) for item in value)
+    raise ValueError(f"Unknown schema kind: {kind!r}")
+
+
+def _type_name(value: Any) -> str:
+    """Human-readable type name for warning messages."""
+    return type(value).__name__
 
 
 def _merge_config(default: Dict[str, Any], user: Dict[str, Any]) -> Dict[str, Any]:

--- a/server/config/schema.py
+++ b/server/config/schema.py
@@ -1,0 +1,41 @@
+"""Schema describing the supported `.mcp-config.yaml` surface."""
+
+STRING = "a string"
+INTEGER = "an integer"
+NUMBER = "a number"
+STRING_LIST = "a list of strings"
+
+# Every key a user may set. Nested mappings are described by nested dictionaries;
+# leaves carry the expected value kind. Keys outside this schema are rejected by
+# `server.config.loader`, so anything added to `.mcp-config.yaml` or to
+# `DEFAULT_CONFIG` has to be declared here too.
+CONFIG_SCHEMA = {
+    "perplexity": {
+        "model_name": STRING,
+        "max_length": INTEGER,
+        "overlap": INTEGER,
+        "device": STRING,
+        "language": STRING,
+        "thresholds": {
+            "ppl_max": NUMBER,
+            "burstiness_min": NUMBER,
+        },
+    },
+    "stylometry": {
+        "default_baseline": STRING,
+        "custom_baselines_dir": STRING,
+        "thresholds": {
+            "warning_z": NUMBER,
+            "error_z": NUMBER,
+            "ai_confidence_threshold": NUMBER,
+        },
+        "features": {
+            "enabled": STRING_LIST,
+            "pos_tags": STRING_LIST,
+        },
+    },
+    "logging": {
+        "level": STRING,
+        "format": STRING,
+    },
+}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,15 @@
 """Test module for configuration management."""
 
+import logging
+from pathlib import Path
 from unittest.mock import patch
 
+import yaml
+
 from server.config import load_config
+from server.config.defaults import DEFAULT_CONFIG
+from server.config.loader import _validate_config
+from server.config.schema import CONFIG_SCHEMA
 
 
 class TestConfigLoading:
@@ -23,13 +30,12 @@ class TestConfigLoading:
     def test_custom_config(self, mock_yaml, mock_exists, mock_open):
         """Test loading custom configuration."""
         mock_exists.return_value = True
-        mock_yaml.return_value = {"test_key": "test_value"}
+        mock_yaml.return_value = {"perplexity": {"model_name": "distilgpt2"}}
 
         config = load_config()
 
         # Should contain the custom value
-        assert "test_key" in config
-        assert config["test_key"] == "test_value"
+        assert config["perplexity"]["model_name"] == "distilgpt2"
 
     @patch("builtins.open")
     @patch("pathlib.Path.exists")
@@ -104,3 +110,230 @@ class TestConfigStructure:
         assert isinstance(config["stylometry"]["thresholds"]["warning_z"], (int, float))
         assert isinstance(config["stylometry"]["thresholds"]["error_z"], (int, float))
         assert isinstance(config["stylometry"]["thresholds"]["ai_confidence_threshold"], (int, float))
+
+
+def _write_config(tmp_path, text):
+    """Write a `.mcp-config.yaml` into a temporary directory and return its path."""
+    config_file = tmp_path / ".mcp-config.yaml"
+    config_file.write_text(text)
+    return str(config_file)
+
+
+def _leaf_paths(mapping, prefix=""):
+    """Yield the dotted path of every non-mapping leaf in a nested dictionary."""
+    for key, value in mapping.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            yield from _leaf_paths(value, path)
+        else:
+            yield path
+
+
+class TestUnknownKeys:
+    """Unknown keys are rejected with a warning naming the full path."""
+
+    def test_misspelled_consumed_key_is_dropped(self, tmp_path, caplog):
+        """A typo such as `max_lenght` warns and leaves the real setting at its default."""
+        path = _write_config(tmp_path, "perplexity:\n  max_lenght: 99\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert "max_lenght" not in config["perplexity"]
+        assert config["perplexity"]["max_length"] == 512
+        assert "perplexity.max_lenght" in caplog.text
+
+    def test_unknown_top_level_section_is_dropped(self, tmp_path, caplog):
+        """An unknown top-level section warns and does not enter the configuration."""
+        path = _write_config(tmp_path, "test_key: test_value\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert "test_key" not in config
+        assert "'test_key'" in caplog.text
+
+    def test_unknown_threshold_is_dropped(self, tmp_path, caplog):
+        """Unknown keys are rejected at every nesting level, not just the top one."""
+        path = _write_config(tmp_path, "stylometry:\n  thresholds:\n    warning_zz: 4.0\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert "warning_zz" not in config["stylometry"]["thresholds"]
+        assert config["stylometry"]["thresholds"]["warning_z"] == 2.0
+        assert "stylometry.thresholds.warning_zz" in caplog.text
+
+    def test_known_siblings_of_an_unknown_key_survive(self, tmp_path, caplog):
+        """Rejecting one key does not discard valid keys beside it."""
+        path = _write_config(tmp_path, "perplexity:\n  max_lenght: 99\n  overlap: 12\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert config["perplexity"]["overlap"] == 12
+        assert config["perplexity"]["max_length"] == 512
+
+
+class TestWrongTypes:
+    """Wrongly typed values are rejected with a path-specific warning."""
+
+    def test_scalar_where_a_mapping_is_required(self, tmp_path, caplog):
+        """`perplexity: gpt2` is rejected instead of reaching the model managers."""
+        path = _write_config(tmp_path, "perplexity: gpt2\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert config["perplexity"] == DEFAULT_CONFIG["perplexity"]
+        assert "'perplexity' must be a mapping, got str" in caplog.text
+
+    def test_scalar_where_a_nested_mapping_is_required(self, tmp_path, caplog):
+        """A scalar in place of a nested section falls back to the default section."""
+        path = _write_config(tmp_path, "perplexity:\n  thresholds: 25.0\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert config["perplexity"]["thresholds"] == DEFAULT_CONFIG["perplexity"]["thresholds"]
+        assert "'perplexity.thresholds' must be a mapping, got float" in caplog.text
+
+    def test_non_numeric_threshold(self, tmp_path, caplog):
+        """A non-numeric threshold warns and falls back to the default."""
+        path = _write_config(tmp_path, 'perplexity:\n  thresholds:\n    ppl_max: "high"\n')
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert config["perplexity"]["thresholds"]["ppl_max"] == 25.0
+        assert "'perplexity.thresholds.ppl_max' must be a number, got str" in caplog.text
+
+    def test_non_integer_max_length(self, tmp_path, caplog):
+        """A float where an integer is required warns and falls back to the default."""
+        path = _write_config(tmp_path, "perplexity:\n  max_length: 512.5\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert config["perplexity"]["max_length"] == 512
+        assert "'perplexity.max_length' must be an integer, got float" in caplog.text
+
+    def test_boolean_is_not_accepted_as_a_number(self, tmp_path, caplog):
+        """YAML booleans are rejected even though `bool` subclasses `int`."""
+        path = _write_config(tmp_path, "perplexity:\n  overlap: true\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert config["perplexity"]["overlap"] == 50
+        assert "'perplexity.overlap' must be an integer, got bool" in caplog.text
+
+    def test_non_string_model_name(self, tmp_path, caplog):
+        """A numeric model name warns and falls back to the default."""
+        path = _write_config(tmp_path, "perplexity:\n  model_name: 2\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert config["perplexity"]["model_name"] == "gpt2"
+        assert "'perplexity.model_name' must be a string, got int" in caplog.text
+
+    def test_feature_list_with_non_string_entries(self, tmp_path, caplog):
+        """A list value is checked element by element."""
+        path = _write_config(tmp_path, "stylometry:\n  features:\n    pos_tags: [NOUN, 3]\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert "pos_tags" not in config["stylometry"].get("features", {})
+        assert "'stylometry.features.pos_tags' must be a list of strings, got list" in caplog.text
+
+    def test_config_file_containing_a_scalar(self, tmp_path, caplog):
+        """A YAML document that is not a mapping falls back to the defaults."""
+        path = _write_config(tmp_path, "just a string\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert config == DEFAULT_CONFIG
+        assert "must contain a mapping, got str" in caplog.text
+
+
+class TestValidOverrides:
+    """Valid configuration still merges recursively."""
+
+    def test_partial_override_preserves_unspecified_defaults(self, tmp_path, caplog):
+        """Overriding one threshold leaves its siblings and other sections untouched."""
+        path = _write_config(
+            tmp_path,
+            "perplexity:\n"
+            "  model_name: distilgpt2\n"
+            "  thresholds:\n"
+            "    ppl_max: 40\n"
+            "stylometry:\n"
+            "  thresholds:\n"
+            "    error_z: 4.5\n",
+        )
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert caplog.text == ""
+        assert config["perplexity"]["model_name"] == "distilgpt2"
+        assert config["perplexity"]["thresholds"]["ppl_max"] == 40
+        assert config["perplexity"]["thresholds"]["burstiness_min"] == 2.5
+        assert config["perplexity"]["max_length"] == 512
+        assert config["stylometry"]["thresholds"]["error_z"] == 4.5
+        assert config["stylometry"]["thresholds"]["warning_z"] == 2.0
+        assert config["logging"] == DEFAULT_CONFIG["logging"]
+
+    def test_integers_are_accepted_where_numbers_are_expected(self, tmp_path, caplog):
+        """An integer is a valid number, so `warning_z: 3` is not a type error."""
+        path = _write_config(tmp_path, "stylometry:\n  thresholds:\n    warning_z: 3\n")
+
+        with caplog.at_level(logging.WARNING):
+            config = load_config(path)
+
+        assert caplog.text == ""
+        assert config["stylometry"]["thresholds"]["warning_z"] == 3
+
+
+class TestSchemaCoverage:
+    """The schema covers everything the server actually reads."""
+
+    # Settings read by `initialize_models` or by the analysis path, as dotted paths.
+    CONSUMED_SETTINGS = [
+        "perplexity.model_name",
+        "perplexity.max_length",
+        "perplexity.overlap",
+        "perplexity.device",
+        "perplexity.thresholds.ppl_max",
+        "perplexity.thresholds.burstiness_min",
+        "stylometry.thresholds.warning_z",
+        "stylometry.thresholds.error_z",
+        "stylometry.thresholds.ai_confidence_threshold",
+    ]
+
+    def test_every_consumed_setting_is_declared(self):
+        """Every setting the server reads has a schema entry."""
+        declared = set(_leaf_paths(CONFIG_SCHEMA))
+        for setting in self.CONSUMED_SETTINGS:
+            assert setting in declared, f"Consumed setting '{setting}' is not validated"
+
+    def test_every_default_is_declared_and_valid(self):
+        """The shipped defaults themselves satisfy the schema."""
+        assert set(_leaf_paths(DEFAULT_CONFIG)) <= set(_leaf_paths(CONFIG_SCHEMA))
+
+        config = _validate_config(DEFAULT_CONFIG, ".mcp-config.yaml")
+        assert config == DEFAULT_CONFIG
+
+    def test_shipped_config_file_validates_cleanly(self, caplog):
+        """The `.mcp-config.yaml` committed to the repository produces no warnings."""
+        shipped = Path(__file__).parent.parent / ".mcp-config.yaml"
+        user_config = yaml.safe_load(shipped.read_text())
+
+        with caplog.at_level(logging.WARNING):
+            validated = _validate_config(user_config, str(shipped))
+
+        assert caplog.text == ""
+        assert validated == user_config


### PR DESCRIPTION
Closes #37

## What changed

`load_config()` merged any YAML mapping into the defaults without checking it. A typo such as `perplexity.max_lenght: 99` was accepted and retained while the real `max_length` silently stayed at 512, and a structurally wrong value such as `perplexity: gpt2` survived loading, reached `GPT2Manager`, and only surfaced much later as `{"error": "Analysis failed: ..."}` from the analysis path.

- **New `server/config/schema.py`** — a declarative description of the supported `.mcp-config.yaml` surface. Nested mappings are nested dictionaries; leaves carry the expected value kind (`a string`, `an integer`, `a number`, `a list of strings`). No new runtime dependency.
- **`server/config/loader.py`** — `load_config()` now runs the user configuration through `_validate_config()` before merging. Unknown keys and wrongly typed values are dropped with a warning naming the full dotted path (`Unknown configuration key 'perplexity.max_lenght' in .mcp-config.yaml. Ignoring it.` / `Configuration key 'perplexity.thresholds.ppl_max' must be a number, got str. Using the default.`), so the field falls back to its default. Valid keys beside a rejected one are unaffected, and valid partial overrides still merge recursively. YAML read/parse failures keep the existing "use defaults" fallback path unchanged.
- `bool` is rejected wherever a number is expected — `overlap: true` would otherwise pass an `isinstance(..., int)` check, since `bool` subclasses `int`.

The schema declares the full documented surface, not just the consumed subset: `stylometry.default_baseline`, `stylometry.custom_baselines_dir`, `stylometry.features.*` and `logging.*` ship in the repo's own `.mcp-config.yaml` but are read by nobody today. They are accepted and type-checked rather than rejected, so loading the shipped file stays warning-free. Per the issue's scope note, nothing here wires or removes them.

## Tests

`tests/test_config.py` gains three classes covering returned values *and* warning text:

- `TestUnknownKeys` — misspelled consumed key, unknown top-level section, unknown key at the deepest nesting level, and that a valid sibling survives its rejected neighbour.
- `TestWrongTypes` — `perplexity: gpt2`, a scalar where a nested mapping belongs, a non-numeric threshold, a float where an integer is required, a boolean where a number is required, a non-string `model_name`, a list with non-string entries, and a YAML document that is not a mapping at all.
- `TestSchemaCoverage` — asserts every setting the server actually reads (`initialize_models` plus `AIDetectionAnalyzer`'s perplexity and stylometry thresholds) has a schema entry, that `DEFAULT_CONFIG` itself validates unchanged, and that the committed `.mcp-config.yaml` validates with no warnings.

The pre-existing `test_custom_config` asserted that an arbitrary `test_key` was retained, which is exactly the behaviour this issue asks to remove; it now exercises a real override (`perplexity.model_name`).

## Verification

Ran on a Python 3.12 venv (`uv venv .venv --python 3.12 --seed` + `uv pip install -e ".[dev]"`):

- `.venv/bin/python -m ruff check .` → `All checks passed!`
- `.venv/bin/python -m ruff format --check .` → `45 files already formatted`
- `.venv/bin/python -m pytest tests/` → **215 passed** in 3.56s

Mutation-tested so the new tests are not vacuous (`PYTHONDONTWRITEBYTECODE=1`, restored from a copy rather than `git checkout`, and the suite confirmed green again afterwards):

- Reverting `load_config` to `_merge_config(config, user_config)` (the pre-fix behaviour): **11 of the new tests fail**, covering both the unknown-key and wrong-type halves.
- Deleting only the `isinstance(value, bool)` guard in `_matches_kind`: **1 test fails** (`test_boolean_is_not_accepted_as_a_number`), and nothing else — so that guard has its own dedicated coverage rather than riding on the others.

Also confirmed by hand that `load_config()` against the repo's committed `.mcp-config.yaml` at `logging.DEBUG` emits no warnings and returns the same merged configuration as before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)