### PR TITLE
Keep model-independent tools from loading spaCy

### DIFF
--- a/server/analyzers/__init__.py
+++ b/server/analyzers/__init__.py
@@ -16,11 +16,23 @@ __all__ = [
 ]
 
 
-def initialize_analyzers(nlp_model, gpt2_manager, config):
-    """Initialize all analyzers with required dependencies."""
+def initialize_model_independent_analyzers():
+    """Initialize the analyzers that need no NLP model.
+
+    These are safe to construct without loading spaCy. ``BasicStatsAnalyzer.spellcheck``
+    still depends on the shared preprocessor, so only the count and readability tools
+    may use this set on its own.
+    """
     return {
         "basic_stats": BasicStatsAnalyzer(),
         "readability": ReadabilityAnalyzer(),
+    }
+
+
+def initialize_analyzers(nlp_model, gpt2_manager, config):
+    """Initialize all analyzers with required dependencies."""
+    return {
+        **initialize_model_independent_analyzers(),
         "keyword": KeywordAnalyzer(nlp_model),
         "style": StyleAnalyzer(nlp_model),
         "ai_detection": AIDetectionAnalyzer(nlp_model, gpt2_manager, config),

--- a/server/analyzers/basic_stats.py
+++ b/server/analyzers/basic_stats.py
@@ -9,7 +9,14 @@ class BasicStatsAnalyzer:
     """Handles basic text statistics like character count, word count, and spellchecking."""
 
     def __init__(self):
-        self.spell_checker = SpellChecker()
+        self._spell_checker = None
+
+    @property
+    def spell_checker(self) -> SpellChecker:
+        """Build the spell checker on first use; only ``spellcheck`` needs it."""
+        if self._spell_checker is None:
+            self._spell_checker = SpellChecker()
+        return self._spell_checker
 
     def character_count(self, text: str) -> int:
         """Calculate the total number of characters in the text."""

--- a/server/app.py
+++ b/server/app.py
@@ -13,7 +13,7 @@ import sys
 from fastmcp import FastMCP
 
 # Analysis imports
-from server.analyzers import initialize_analyzers
+from server.analyzers import initialize_analyzers, initialize_model_independent_analyzers
 
 # Configuration imports
 from server.config import load_config
@@ -40,6 +40,20 @@ gpt2_manager = model_managers["gpt2"]
 
 # Analyzers will be initialized lazily on first use
 _analyzers = None
+_model_independent_analyzers = None
+
+
+def get_model_independent_analyzers():
+    """Lazily initialize and return the analyzers that need no NLP model.
+
+    Deliberately separate from :func:`get_analyzers` so the count and readability
+    tools never trigger a spaCy load they cannot use.
+    """
+    global _model_independent_analyzers
+    if _model_independent_analyzers is None:
+        _model_independent_analyzers = initialize_model_independent_analyzers()
+        logger.info("Model-independent analyzers initialized on first use (no NLP model loaded)")
+    return _model_independent_analyzers
 
 
 def get_analyzers():
@@ -114,7 +128,6 @@ def list_tools():
 
 
 @mcp.tool()
-@auto_cleanup("spacy")
 def character_count(text: str) -> int:
     """Calculates the total number of characters in the provided text.
 
@@ -124,11 +137,10 @@ def character_count(text: str) -> int:
     Returns:
         int: The total character count of the input text.
     """
-    return get_analyzers()["basic_stats"].character_count(text)
+    return get_model_independent_analyzers()["basic_stats"].character_count(text)
 
 
 @mcp.tool()
-@auto_cleanup("spacy")
 def word_count(text: str) -> int:
     """Calculates the total number of words in the provided text, splitting by whitespace.
 
@@ -138,7 +150,7 @@ def word_count(text: str) -> int:
     Returns:
         int: The total word count of the input text.
     """
-    return get_analyzers()["basic_stats"].word_count(text)
+    return get_model_independent_analyzers()["basic_stats"].word_count(text)
 
 
 @mcp.tool()
@@ -159,7 +171,6 @@ def spellcheck(text: str):
 
 
 @mcp.tool()
-@auto_cleanup("spacy")
 def readability_score(text: str, level: str = "full") -> dict:
     """
     Calculates various readability scores (Flesch Reading Ease, Flesch-Kincaid Grade Level,
@@ -180,11 +191,10 @@ def readability_score(text: str, level: str = "full") -> dict:
               - If `level` is "paragraph": `{"full_text": {...}, "paragraphs": [{"paragraph_number": int, "text": str, "scores": {...}}, ...]}`
               - If `level` is invalid: `{"error": str}`
     """
-    return get_analyzers()["readability"].readability_score(text, level)
+    return get_model_independent_analyzers()["readability"].readability_score(text, level)
 
 
 @mcp.tool()
-@auto_cleanup("spacy")
 def reading_time(text: str, level: str = "full") -> dict:
     """
     Estimates the reading time for the input text using textstat. The estimation
@@ -204,7 +214,7 @@ def reading_time(text: str, level: str = "full") -> dict:
               - If `level` is "paragraph": `{"full_text": float, "paragraphs": [{"paragraph_number": int, "text": str, "reading_time_minutes": float}, ...]}`
               - If `level` is invalid: `{"error": str}`
     """
-    return get_analyzers()["readability"].reading_time(text, level)
+    return get_model_independent_analyzers()["readability"].reading_time(text, level)
 
 
 @mcp.tool()

--- a/tests/test_model_independent_tools.py
+++ b/tests/test_model_independent_tools.py
@@ -1,0 +1,188 @@
+"""Test module for the tool wrappers that must never touch an NLP model.
+
+``character_count``, ``word_count``, ``readability_score`` and ``reading_time``
+delegate to analyzers built without spaCy, so they must not go through
+``get_analyzers()`` (which loads the model) or declare spaCy cleanup.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from server import app
+from server.analyzers import BasicStatsAnalyzer, ReadabilityAnalyzer
+
+MODEL_INDEPENDENT_TOOLS = [
+    (app.character_count, ("Some sample text here.",)),
+    (app.word_count, ("Some sample text here.",)),
+    (app.readability_score, ("Some sample text here.", "full")),
+    (app.reading_time, ("Some sample text here.", "full")),
+]
+MODEL_INDEPENDENT_TOOL_IDS = [tool.__name__ for tool, _ in MODEL_INDEPENDENT_TOOLS]
+
+
+@pytest.fixture
+def mock_managers():
+    """Replace the module-level model managers so no real model is ever loaded."""
+    spacy_manager = Mock()
+    spacy_manager.get_model.return_value = Mock(name="nlp")
+    gpt2_manager = Mock()
+
+    with (
+        patch.object(app, "spacy_manager", spacy_manager),
+        patch.object(app, "gpt2_manager", gpt2_manager),
+    ):
+        yield {"spacy": spacy_manager, "gpt2": gpt2_manager}
+
+
+@pytest.fixture(autouse=True)
+def reset_analyzer_caches():
+    """Keep the module-level analyzer caches from leaking between tests."""
+    app._analyzers = None
+    app._model_independent_analyzers = None
+    yield
+    app._analyzers = None
+    app._model_independent_analyzers = None
+
+
+class TestNoModelInitialization:
+    """The four wrappers must not request, initialize or unload spaCy."""
+
+    @pytest.mark.parametrize("tool, args", MODEL_INDEPENDENT_TOOLS, ids=MODEL_INDEPENDENT_TOOL_IDS)
+    def test_tool_never_loads_or_unloads_spacy(self, tool, args, mock_managers):
+        factory = Mock(side_effect=AssertionError("get_analyzers() must not be used by this tool"))
+
+        with (
+            patch.object(app, "initialize_analyzers", factory),
+            patch.object(app, "initialize_preprocessor", Mock()) as preprocessor,
+            patch.object(app, "initialize_sentence_splitter", Mock()) as splitter,
+        ):
+            tool(*args)
+
+        mock_managers["spacy"].get_model.assert_not_called()
+        mock_managers["spacy"].unload_model.assert_not_called()
+        mock_managers["gpt2"].unload_model.assert_not_called()
+        factory.assert_not_called()
+        preprocessor.assert_not_called()
+        splitter.assert_not_called()
+        assert app._analyzers is None
+
+    def test_analyzer_set_holds_only_model_independent_analyzers(self, mock_managers):
+        analyzers = app.get_model_independent_analyzers()
+
+        assert set(analyzers) == {"basic_stats", "readability"}
+        assert isinstance(analyzers["basic_stats"], BasicStatsAnalyzer)
+        assert isinstance(analyzers["readability"], ReadabilityAnalyzer)
+        mock_managers["spacy"].get_model.assert_not_called()
+
+    def test_analyzer_set_is_cached(self, mock_managers):
+        assert app.get_model_independent_analyzers() is app.get_model_independent_analyzers()
+
+    def test_cached_set_does_not_retain_a_spell_checker(self, mock_managers):
+        """The cache outlives cleanup, so it must not hold the spellchecker dictionary."""
+        with patch("server.analyzers.basic_stats.SpellChecker") as spell_checker_cls:
+            app.character_count("hello world")
+            app.word_count("hello world")
+
+            spell_checker_cls.assert_not_called()
+
+            app.get_model_independent_analyzers()["basic_stats"].spellcheck("hello world")
+
+            spell_checker_cls.assert_called_once_with()
+
+    def test_cleanup_leaves_model_independent_analyzers_usable(self, mock_managers):
+        app.cleanup_models("spacy")
+
+        assert app.character_count("hello world") == 11
+        mock_managers["spacy"].get_model.assert_not_called()
+
+
+class TestDelegation:
+    """The wrappers must stay thin — the project analyzers do the work."""
+
+    def test_character_count_delegates(self, mock_managers):
+        with patch.object(BasicStatsAnalyzer, "character_count", return_value=1234) as method:
+            assert app.character_count("hello world") == 1234
+
+        method.assert_called_once_with("hello world")
+
+    def test_word_count_delegates(self, mock_managers):
+        with patch.object(BasicStatsAnalyzer, "word_count", return_value=99) as method:
+            assert app.word_count("hello world") == 99
+
+        method.assert_called_once_with("hello world")
+
+    def test_readability_score_delegates(self, mock_managers):
+        sentinel = {"flesch": 1.0, "kincaid": 2.0, "fog": 3.0}
+
+        with patch.object(ReadabilityAnalyzer, "readability_score", return_value=sentinel) as method:
+            assert app.readability_score("hello world", "paragraph") is sentinel
+
+        method.assert_called_once_with("hello world", "paragraph")
+
+    def test_reading_time_delegates(self, mock_managers):
+        sentinel = {"full_text": 4.2}
+
+        with patch.object(ReadabilityAnalyzer, "reading_time", return_value=sentinel) as method:
+            assert app.reading_time("hello world", "section") is sentinel
+
+        method.assert_called_once_with("hello world", "section")
+
+
+class TestResultsUnchanged:
+    """Public result shapes and values must match the analyzers' own output."""
+
+    TEXT = "# Heading\n\nThe quick brown fox jumps over the lazy dog. It ran away.\n\nA second paragraph here."
+
+    @pytest.mark.parametrize("level", ["full", "section", "paragraph", "bogus"])
+    def test_readability_score_matches_analyzer(self, level, mock_managers):
+        assert app.readability_score(self.TEXT, level) == ReadabilityAnalyzer().readability_score(self.TEXT, level)
+
+    @pytest.mark.parametrize("level", ["full", "section", "paragraph", "bogus"])
+    def test_reading_time_matches_analyzer(self, level, mock_managers):
+        assert app.reading_time(self.TEXT, level) == ReadabilityAnalyzer().reading_time(self.TEXT, level)
+
+    def test_counts_match_analyzer(self, mock_managers):
+        analyzer = BasicStatsAnalyzer()
+
+        assert app.character_count(self.TEXT) == analyzer.character_count(self.TEXT) == len(self.TEXT)
+        assert app.word_count(self.TEXT) == analyzer.word_count(self.TEXT) == len(self.TEXT.split())
+
+    def test_default_level_is_full(self, mock_managers):
+        assert app.readability_score(self.TEXT) == app.readability_score(self.TEXT, "full")
+        assert app.reading_time(self.TEXT) == app.reading_time(self.TEXT, "full")
+
+
+class TestNlpToolsStillLoadAndCleanUp:
+    """The NLP-dependent tools keep their lazy-load and cleanup-on-exit behavior."""
+
+    @pytest.fixture
+    def mock_analyzers(self):
+        analyzers = {name: Mock() for name in ("basic_stats", "keyword", "style")}
+
+        with (
+            patch.object(app, "initialize_analyzers", Mock(return_value=analyzers)),
+            patch.object(app, "initialize_preprocessor", Mock()),
+            patch.object(app, "initialize_sentence_splitter", Mock()),
+        ):
+            yield analyzers
+
+    @pytest.mark.parametrize(
+        "tool, args, key, method, expected_call",
+        [
+            (app.spellcheck, ("some text",), "basic_stats", "spellcheck", ("some text",)),
+            (app.keyword_frequency, ("some text",), "keyword", "keyword_frequency", ("some text", True)),
+            (app.passive_voice_detection, ("some text",), "style", "passive_voice_detection", ("some text",)),
+        ],
+        ids=["spellcheck", "keyword_frequency", "passive_voice_detection"],
+    )
+    def test_nlp_tool_loads_then_unloads_spacy(
+        self, tool, args, key, method, expected_call, mock_managers, mock_analyzers
+    ):
+        tool(*args)
+
+        mock_managers["spacy"].get_model.assert_called_once_with()
+        mock_managers["spacy"].unload_model.assert_called_once_with()
+        mock_managers["gpt2"].unload_model.assert_not_called()
+        assert app._analyzers is None
+        getattr(mock_analyzers[key], method).assert_called_once_with(*expected_call)


### PR DESCRIPTION
Closes #32

## What changed

`character_count`, `word_count`, `readability_score` and `reading_time` delegate to `BasicStatsAnalyzer` and `ReadabilityAnalyzer`, neither of which is constructed with an NLP model. They nevertheless routed through `get_analyzers()`, which calls `spacy_manager.get_model()` unconditionally, and then unloaded the model again through `@auto_cleanup("spacy")` — a full load/download plus unload per call, for analyzers that never touch it.

- `server/analyzers/__init__.py`: new `initialize_model_independent_analyzers()` is now the single definition of which analyzers need no model. `initialize_analyzers()` composes it, so the two sets cannot drift.
- `server/app.py`: new `get_model_independent_analyzers()` with its own lazy module-level cache, deliberately separate from `get_analyzers()`. The four wrappers use it and no longer declare `@auto_cleanup("spacy")`. Everything else (`spellcheck`, the keyword tools, `passive_voice_detection`, `perplexity_analysis`, `stylometric_analysis`) is untouched and keeps its lazy-load and cleanup-on-success/error behavior.
- `server/analyzers/basic_stats.py`: `BasicStatsAnalyzer` builds its `SpellChecker` on first use rather than in `__init__`.

That last one is a consequence of the cache, not scope creep: the model-independent set is never cleared by `cleanup_models`, and an eager `SpellChecker()` measured at ~12.8 MB retained (`tracemalloc`) and ~70–90 ms to build. Caching it permanently would have traded a spaCy load for a permanent 13 MB of dictionary that only `spellcheck()` ever reads, which runs against this server's low-idle-memory design. Making it lazy keeps the cached set effectively free while `spellcheck` pays exactly what it paid before. `spell_checker` remains a public attribute (now a property), so callers are unaffected.

Result shapes and values are unchanged — the wrappers are still one-line delegations to the same analyzer methods.

## Verification

Environment: `uv venv .venv --python 3.12 --seed` + `uv pip install --python "$PWD/.venv/bin/python" -e ".[dev]"`.

Full CI gate, all green:

```
.venv/bin/python -m ruff check .          # All checks passed!
.venv/bin/python -m ruff format --check . # 46 files already formatted
.venv/bin/python -m pytest tests/ -q      # 240 passed in 2.91s  (215 on the base commit)
```

**End-to-end, fresh process, no mocks** — the four tools run and `spacy_manager._model` is still `None` afterwards, while `spellcheck` still loads and unloads:

```
character_count: 11 0.0001s
word_count: 2 0.0000s
readability_score: {'flesch': 94.3, 'kincaid': 2.34, 'fog': 3.6} 0.4978s   # textstat/markdown-it import, not spaCy
reading_time: {'full_text': 0.0168} 0.0001s
spacy loaded at all?  False
spellcheck (NLP path): 0.523s, spacy unloaded after: True
```

Same probe against the base commit, for the cost being removed:

```
character_count (BASE): 0.589s
word_count (BASE): 0.429s
reading_time (BASE): 0.445s
```

**New tests** — `tests/test_model_independent_tools.py` (25 tests):

- `TestNoModelInitialization` — each of the four tools runs with `app.spacy_manager` mocked and asserts `get_model` / `unload_model` were never called, `initialize_analyzers` / `initialize_preprocessor` / `initialize_sentence_splitter` were never called, and `app._analyzers` stays `None`.
- `TestDelegation` — patches `BasicStatsAnalyzer.character_count`, `BasicStatsAnalyzer.word_count`, `ReadabilityAnalyzer.readability_score`, `ReadabilityAnalyzer.reading_time` and asserts each wrapper forwards its arguments and returns the analyzer's value, so the wrappers cannot silently reimplement the logic.
- `TestResultsUnchanged` — compares wrapper output against a directly-constructed analyzer for `full` / `section` / `paragraph` / an invalid level, plus exact `len(text)` and `len(text.split())` values.
- `TestNlpToolsStillLoadAndCleanUp` — `spellcheck`, `keyword_frequency` and `passive_voice_detection` still request spaCy exactly once, unload it exactly once, leave GPT-2 alone, and clear the analyzer cache.

**Mutation-tested** (each mutation applied to the committed fix, suite re-run, then restored; `PYTHONDONTWRITEBYTECODE=1` and `__pycache__` cleared between runs):

| Mutation | Caught by |
|---|---|
| `character_count` back to `get_analyzers()` + `@auto_cleanup("spacy")` | `test_tool_never_loads_or_unloads_spacy[character_count]`, `test_cleanup_leaves_model_independent_analyzers_usable` |
| same for `word_count` | `test_tool_never_loads_or_unloads_spacy[word_count]` |
| same for `readability_score` | `test_tool_never_loads_or_unloads_spacy[readability_score]` |
| same for `reading_time` | `test_tool_never_loads_or_unloads_spacy[reading_time]` |
| `character_count` reimplemented inline as `len(text)` instead of delegating | `TestDelegation::test_character_count_delegates` |
| `@auto_cleanup("spacy")` dropped from `spellcheck` | `TestNlpToolsStillLoadAndCleanUp::test_nlp_tool_loads_then_unloads_spacy[spellcheck]` |
| `SpellChecker()` moved back into `BasicStatsAnalyzer.__init__` | `test_cached_set_does_not_retain_a_spell_checker` |

Suite restored to 240 passing after every mutation.