### PR TITLE
Match complete multi-word keywords in density and context

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ Below is a detailed reference for each tool provided by the server.
 
 **`keyword_density`**
 
-*   **Description**: Calculate the density of a given keyword in the text (case-insensitive, lemmatized).
+*   **Description**: Calculate the density of a given keyword in the text (case-insensitive, lemmatized). Multi-word keywords are matched as complete, contiguous phrases.
 *   **Parameters**:
     *   `text` (`str`): The text to analyze.
-    *   `keyword` (`str`): The keyword to search for.
+    *   `keyword` (`str`): The keyword or phrase to search for.
 *   **Returns**: `float` - The density percentage ( (keyword count / total words) * 100 ).
 
 ---
@@ -189,11 +189,11 @@ Below is a detailed reference for each tool provided by the server.
 
 **`keyword_context`**
 
-*   **Description**: Extract sentences where a specific keyword (case-insensitive, lemmatized) appears.
+*   **Description**: Extract sentences where a specific keyword (case-insensitive, lemmatized) appears. Multi-word keywords are matched as complete, contiguous phrases.
 *   **Parameters**:
     *   `text` (`str`): The text to search within.
-    *   `keyword` (`str`): The keyword to find.
-*   **Returns**: `list[str]` - A list of sentences containing the keyword or its lemma.
+    *   `keyword` (`str`): The keyword or phrase to find.
+*   **Returns**: `list[str]` - A list of sentences containing the keyword or phrase, matched on lemmas.
 
 ---
 

--- a/server/analyzers/keyword_analysis.py
+++ b/server/analyzers/keyword_analysis.py
@@ -11,12 +11,23 @@ class KeywordAnalyzer:
     def __init__(self, nlp_model):
         self.nlp = nlp_model
 
+    @staticmethod
+    def _count_sequence(tokens: list[str], keyword_tokens: list[str]) -> int:
+        """Count contiguous occurrences of a token sequence."""
+        keyword_length = len(keyword_tokens)
+        if keyword_length == 0:
+            return 0
+        return sum(
+            tokens[index : index + keyword_length] == keyword_tokens
+            for index in range(len(tokens) - keyword_length + 1)
+        )
+
     def keyword_density(self, text: str, keyword: str) -> float:
         """Calculate the density of a specific keyword within the text."""
         processed_text = preprocess_text(text)
-        processed_keyword = preprocess_text(keyword)[0] if preprocess_text(keyword) else keyword.lower()
+        processed_keyword = preprocess_text(keyword)
 
-        keyword_count = processed_text.count(processed_keyword)
+        keyword_count = self._count_sequence(processed_text, processed_keyword)
         return (keyword_count / len(processed_text)) * 100 if processed_text else 0
 
     def keyword_frequency(self, text: str, remove_stopwords: bool = True) -> dict:
@@ -34,14 +45,15 @@ class KeywordAnalyzer:
         """Extract sentences from the text that contain a specific keyword or its lemma."""
         doc = self.nlp(text)
 
-        # Process the keyword to get its lemma
         keyword_doc = self.nlp(keyword.lower())
-        keyword_lemma = keyword_doc[0].lemma_ if len(keyword_doc) > 0 else keyword.lower()
+        keyword_tokens = [token.lemma_.lower() for token in keyword_doc if not token.is_punct and not token.is_space]
+        if not keyword_tokens:
+            return []
 
-        # Extract sentences containing the keyword or its lemmatized form
         contexts = []
         for sent in doc.sents:
-            if any(token.text.lower() == keyword.lower() or token.lemma_ == keyword_lemma for token in sent):
+            sentence_tokens = [token.lemma_.lower() for token in sent if not token.is_punct and not token.is_space]
+            if self._count_sequence(sentence_tokens, keyword_tokens):
                 contexts.append(sent.text)
 
         return contexts

--- a/tests/test_keyword_phrases.py
+++ b/tests/test_keyword_phrases.py
@@ -1,0 +1,42 @@
+"""Value-based tests for keyword and phrase matching."""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("text", "keyword", "expected_density"),
+    [
+        (
+            "Artificial intelligence changes work. Artificial methods differ. "
+            "Artificial intelligence improves systems.",
+            "artificial intelligence",
+            200 / 11,
+        ),
+        ("Artificial methods improve intelligence. Artificial intelligence works.", "artificial intelligence", 100 / 7),
+        ("Running teams run daily.", "RUN", 50.0),
+        ("Models run quickly. A model runs daily.", "model run", 100 / 3),
+        ("Words remain.", "", 0),
+        ("Words remain.", "...", 0),
+    ],
+)
+def test_keyword_density_exact_values(keyword_analyzer, text, keyword, expected_density):
+    assert keyword_analyzer.keyword_density(text, keyword) == pytest.approx(expected_density)
+
+
+@pytest.mark.parametrize("keyword", ["", "..."])
+def test_empty_keyword_has_no_context(keyword_analyzer, keyword):
+    assert keyword_analyzer.keyword_context("Words remain. More words follow.", keyword) == []
+
+
+def test_keyword_context_matches_only_complete_phrase(keyword_analyzer):
+    text = "Artificial methods differ. Artificial methods improve intelligence. Artificial intelligence changes work."
+
+    assert keyword_analyzer.keyword_context(text, "artificial intelligence") == [
+        "Artificial intelligence changes work."
+    ]
+
+
+def test_keyword_context_is_case_insensitive_and_lemmatized(keyword_analyzer):
+    text = "Models run quickly. A model rests. Different systems RUN daily."
+
+    assert keyword_analyzer.keyword_context(text, "MODEL RUN") == ["Models run quickly."]


### PR DESCRIPTION
Closes #31

`KeywordAnalyzer` silently reduced a multi-word keyword to its first processed token, so the README's own `keyword="artificial intelligence"` example counted every occurrence of `artificial` and returned sentences that contained only that word.

## What changed

`server/analyzers/keyword_analysis.py`:

- Added `_count_sequence(tokens, keyword_tokens)`, a shared helper that counts contiguous occurrences of a token sequence and returns `0` for an empty sequence.
- `keyword_density()` now normalizes the keyword into a full token list via `preprocess_text` (instead of taking `[0]`) and counts contiguous sequence matches. Both text and keyword go through the same lemmatizing, stopword-removing pipeline, so the match stays self-consistent, and the denominator is unchanged.
- `keyword_context()` builds a lowercased-lemma token list per keyword and per sentence, skipping punctuation and whitespace, and keeps a sentence only when the complete contiguous sequence occurs. An empty or punctuation-only keyword returns `[]` before any sentence is scanned.

Single-token behavior is unchanged: a one-token sequence match is exactly the old per-token comparison.

`README.md`: the two tool descriptions said "case-insensitive, lemmatized" but nothing about phrase behavior, which is the part that actually changed. Added one clause to each.

## Behavior change

Callers passing a multi-word `keyword` will get different (correct) results. Single-word queries are unaffected.

## Verification

Environment: `uv venv .venv --python 3.12 --seed` + `uv pip install -e ".[dev]"`, gates driven as `.venv/bin/python -m <tool>`.

Full gate, on the final commit:

- `ruff check .` — All checks passed
- `ruff format --check .` — 46 files already formatted
- `pytest tests/` — **225 passed**

The issue's headline example, run against the real `en_core_web_sm` model:

```
text = "Artificial methods differ. Artificial intelligence changes work."

context("artificial intelligence")  -> ['Artificial intelligence changes work.']   # was both sentences
density("artificial intelligence")  -> 14.286                                      # was 28.571
density("artificial")               -> 28.571   # single-token behavior preserved
context("ARTIFICIAL INTELLIGENCE")  -> ['Artificial intelligence changes work.']   # case-insensitive
context("changing work")            -> ['Artificial intelligence changes work.']   # inflected/lemmatized
density("") -> 0.0   context("") -> []
density("...") -> 0.0   context("...") -> []
```

### Mutation testing

The new tests assert exact densities and exact context lists, so they are not shape-only. Each mutation was applied with `__pycache__` cleared and confirmed live at the interpreter level before running the suite; the tree was restored and re-verified green (225 passed) afterwards.

| Mutation | Result |
|---|---|
| Reinstate the original first-token matching in both methods | **4 failed** — both multi-word density cases, plus both context tests |
| Replace contiguous matching with non-contiguous "all tokens present anywhere" (the plausible wrong fix) | **4 failed** — repeated-phrase count, repeated single-token count, `model run`, and the phrase-context test |
| Delete both empty-keyword guards | **4 failed** — the empty and punctuation-only density cases and both empty-context cases |

The second mutation is the one that matters for pinning the intended replacement rather than just killing the original symptom: the `"Artificial methods improve intelligence. Artificial intelligence works."` fixture contains both tokens non-contiguously, and the repeated-phrase fixtures pin counts rather than mere presence.

The empty/punctuation-only cases pass on the original code too (`list.count("")` is `0`), so they document the new explicit guards rather than catching the original bug — the third mutation is what gives them teeth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)